### PR TITLE
Added possibility to move entries in TOC up and down.

### DIFF
--- a/src/Sigil/Dialogs/EditTOC.h
+++ b/src/Sigil/Dialogs/EditTOC.h
@@ -64,12 +64,15 @@ private slots:
     void DeleteEntry();
     void MoveLeft();
     void MoveRight();
+    void MoveUp();
+    void MoveDown();
     void SelectTarget();
 
     void OpenContextMenu(const QPoint &point);
 
 private:
     void AddEntry(bool above);
+    QModelIndex CheckSelection();
 
     NCXModel::NCXEntry ConvertTableToEntries();
     NCXModel::NCXEntry ConvertItemToEntry(QStandardItem *item);
@@ -107,6 +110,8 @@ private:
     QAction *m_Delete;
     QAction *m_CollapseAll;
     QAction *m_ExpandAll;
+    QAction *m_MoveDown;
+    QAction *m_MoveUp;
 
     NCXModel *m_NCXModel;
 

--- a/src/Sigil/Form_Files/EditTOC.ui
+++ b/src/Sigil/Form_Files/EditTOC.ui
@@ -49,23 +49,20 @@
        <item>
         <widget class="QPushButton" name="AddEntryAbove">
          <property name="toolTip">
-          <string>Add a new TOC entry.</string>
+          <string>Insert a blank entry above the currently selected entry.</string>
          </property>
          <property name="text">
           <string>Add Above</string>
-         </property>
-         <property name="toolTip">
-          <string>Insert a blank entry above the currently selected entry.</string>
          </property>
         </widget>
        </item>
        <item>
         <widget class="QPushButton" name="AddEntryBelow">
-         <property name="text">
-          <string>Add Below</string>
-         </property>
          <property name="toolTip">
           <string>Add a blank entry below the currently selected entry.</string>
+         </property>
+         <property name="text">
+          <string>Add Below</string>
          </property>
         </widget>
        </item>
@@ -81,11 +78,11 @@
        </item>
        <item>
         <widget class="QPushButton" name="SelectTarget">
-         <property name="text">
-          <string>Select Target</string>
-         </property>
          <property name="toolTip">
           <string>Set the destination of the TOC entry from a list of valid targets in the book.</string>
+         </property>
+         <property name="text">
+          <string>Select Target</string>
          </property>
         </widget>
        </item>
@@ -120,6 +117,30 @@ You can also use the left arrow key.</string>
             <enum>Qt::LeftArrow</enum>
            </property>
           </widget>
+         </item>
+         <item>
+          <layout class="QVBoxLayout" name="verticalLayout_3">
+           <item>
+            <widget class="QToolButton" name="MoveUp">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="arrowType">
+              <enum>Qt::UpArrow</enum>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QToolButton" name="MoveDown">
+             <property name="text">
+              <string>...</string>
+             </property>
+             <property name="arrowType">
+              <enum>Qt::DownArrow</enum>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item>
           <widget class="QToolButton" name="MoveRight">


### PR DESCRIPTION
TOC entries can now be moved up and down (within the bounds of its parent).
The user interface provides two more QToolButtons (up & down), the keyboard shortcuts are set to Qt::ControlModifier + Qt::Key_Up / Qt::Key_Down.
