### PR TITLE
do not break OPF file when saving EPUB3 file

### DIFF
--- a/src/Sigil/ResourceObjects/OPFResource.cpp
+++ b/src/Sigil/ResourceObjects/OPFResource.cpp
@@ -1196,8 +1196,9 @@ void OPFResource::AddModificationDateMeta()
         XhtmlDoc::GetTagMatchingDescendants(*document, "date", DUBLIN_CORE_NS);
     foreach(xc::DOMElement * meta, metas) {
         QString name = XtoQ(meta->getAttribute(QtoX("opf:event")));
+        QString epub_version = GetEpubVersion(*document);
 
-        if (name == "modification") {
+        if (name == "modification" || epub_version == "3.0") {
             meta->setTextContent(QtoX(date));
             UpdateTextFromDom(*document);
             return;
@@ -1435,6 +1436,17 @@ QString OPFResource::GetOPFDefaultText()
 void OPFResource::FillWithDefaultText()
 {
     SetText(GetOPFDefaultText());
+}
+
+
+QString OPFResource::GetEpubVersion(const xc::DOMDocument &document) const
+{
+    xc::DOMElement *package = GetPackageElement(document);
+    if (!package) {
+        return NULL;
+    }
+    QString epub_version = XtoQ(package->getAttribute(QtoX("version")));
+    return epub_version;
 }
 
 

--- a/src/Sigil/ResourceObjects/OPFResource.h
+++ b/src/Sigil/ResourceObjects/OPFResource.h
@@ -271,6 +271,8 @@ private:
 
     void FillWithDefaultText();
 
+    QString GetEpubVersion(const xc::DOMDocument &document) const;
+
     QString GetUniqueID(const QString &preferred_id, const xc::DOMDocument &document) const;
 
     QString GetResourceMimetype(const Resource &resource) const;


### PR DESCRIPTION
I know Sigil is EPUB2 editor and it's ridiculous to edit EPUB3 files and break them on current Sigil.  It's not Sigil problem, but user's mistake.  But almost all novels, essays and non-ficiton e-books now in Japan use EPUB3, because they want to use vertical writing in CSS3.  And they try and try to edit them with EPUB2 editors like Sigil (and break them. :disappointed:)

And I saw the blog entry "Sigil's Spiritual Successor".  Sigil was, and is, the most famous EPUB editor in Japanese EPUB community.  We really appreciate everything of Sigil.
I don't know C++ well so I can't contribute development actively, but what I can do for you is making patch.  So I wrote this Pull Request.

I'm not sure this patch is good for Sigil as EPUB2 editor. If you don't think it suitable, please feel free to reject and close the issue. Thanks.
