### PR TITLE
Add application category for OSX

### DIFF
--- a/src/Sigil/Resource_Files/mac/MacOSXBundleInfo.plist
+++ b/src/Sigil/Resource_Files/mac/MacOSXBundleInfo.plist
@@ -53,5 +53,7 @@
 	<true/>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
+    <key>LSApplicationCategoryType</key>
+    <string>public.app-category.productivity</string>
 </dict>
 </plist>


### PR DESCRIPTION
When the Application folder is viewed by Arrange --> Application Category it will sort apps without LSApplicationCategoryType into "Other" at the bottom. This adds "Productivity" as the category.
