### PR TITLE
Hardcode menu Plugins in UI, move it before menu Help

### DIFF
--- a/src/Sigil/Form_Files/main.ui
+++ b/src/Sigil/Form_Files/main.ui
@@ -50,7 +50,7 @@
      <x>0</x>
      <y>0</y>
      <width>1000</width>
-     <height>22</height>
+     <height>24</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuFile">
@@ -331,6 +331,12 @@
     <addaction name="actionDeleteUnusedMedia"/>
     <addaction name="actionDeleteUnusedStyles"/>
    </widget>
+   <widget class="QMenu" name="menuPlugins">
+    <property name="title">
+     <string>Plugins</string>
+    </property>
+    <addaction name="actionManage_Plugins"/>
+   </widget>
    <addaction name="menuFile"/>
    <addaction name="menuEdit"/>
    <addaction name="menuInsert"/>
@@ -339,6 +345,7 @@
    <addaction name="menuTools"/>
    <addaction name="menuView"/>
    <addaction name="menuWindow"/>
+   <addaction name="menuPlugins"/>
    <addaction name="menuHelp"/>
   </widget>
   <widget class="QStatusBar" name="statusbar"/>
@@ -2260,6 +2267,11 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+D</string>
+   </property>
+  </action>
+  <action name="actionManage_Plugins">
+   <property name="text">
+    <string>Manage Plugins</string>
    </property>
   </action>
  </widget>

--- a/src/Sigil/MainUI/MainWindow.cpp
+++ b/src/Sigil/MainUI/MainWindow.cpp
@@ -170,11 +170,9 @@ MainWindow::MainWindow(const QString &openfilepath, QWidget *parent, Qt::WindowF
     m_PreviousHTMLResource(NULL),
     m_PreviousHTMLText(QString()),
     m_PreviousHTMLLocation(QList<ViewEditor::ElementIndex>()),
-    m_menuPlugins(NULL),
     m_menuPluginsInput(NULL),
     m_menuPluginsOutput(NULL),
     m_menuPluginsEdit(NULL),
-    m_actionManagePlugins(NULL),
     m_SaveCSS(false)
 {
     ui.setupUi(this);
@@ -217,15 +215,14 @@ MainWindow::~MainWindow()
 // Actions can be removed
 void MainWindow::loadPluginsMenu()
 {
+    m_menuPlugins=ui.menuPlugins;
+    m_actionManagePlugins=ui.actionManage_Plugins;
+
     unloadPluginsMenu();
 
     PluginDB *pdb = PluginDB::instance();
 
-    if (m_menuPlugins == NULL) {
-        m_menuPlugins = ui.menubar->addMenu(tr("Plugins"));
-        m_actionManagePlugins = m_menuPlugins->addAction(tr("Manage Plugins"));
-        connect(m_actionManagePlugins, SIGNAL(triggered()), this, SLOT(ManagePluginsDialog()));
-    }
+    connect(m_actionManagePlugins, SIGNAL(triggered()), this, SLOT(ManagePluginsDialog()));
 
     QHash<QString, Plugin *> plugins = pdb->all_plugins();
     QStringList keys = plugins.keys();


### PR DESCRIPTION
Just getting to know how it functions... 
I find menu Help should be last one... and as menu Plugin is always there it could be hardcoded into main UI. Let me know if I missed something.
