### PR TITLE
prevent saving to Sigil temporary folder

### DIFF
--- a/src/Sigil/MainUI/MainWindow.cpp
+++ b/src/Sigil/MainUI/MainWindow.cpp
@@ -686,6 +686,12 @@ void MainWindow::OpenRecentFile()
 
 bool MainWindow::Save()
 {
+    QString sMF=m_Book->GetFolderKeeper().GetFullPathToMainFolder();
+    sMF=sMF.left(sMF.lastIndexOf("scratchpad"));
+    QString cFP=m_CurrentFilePath.left(m_CurrentFilePath.lastIndexOf("scratchpad"));
+    if(sMF==cFP)
+        m_CurrentFilePath.clear(); //saving to temporary not allowed
+
     if (m_CurrentFilePath.isEmpty()) {
         return SaveAs();
     } else {


### PR DESCRIPTION
When trying to save to Sigil tmp (for instance after successful input plugin execution) user will get Save As dialog.
