### PR TITLE
Add plugin dialog remembers last folder opened

### DIFF
--- a/src/Sigil/Dialogs/PreferenceWidgets/PluginWidget.cpp
+++ b/src/Sigil/Dialogs/PreferenceWidgets/PluginWidget.cpp
@@ -15,11 +15,14 @@
 #include "Misc/Plugin.h"
 #include "Misc/PluginDB.h"
 #include "Misc/Utility.h"
+#include "Misc/SettingsStore.h"
 
+static const QString PLUGINS_SETTINGS_STORE_GROUP = "plugins_dialog";
 
 PluginWidget::PluginWidget()
     :
-    m_isDirty(false)
+    m_isDirty(false),
+    m_LastFolderOpen(QString())
 {
     ui.setupUi(this);
     readSettings();
@@ -56,6 +59,12 @@ void PluginWidget::setPluginTableRow(Plugin *p, int row)
 
 void PluginWidget::readSettings()
 {
+    SettingsStore settings;
+    settings.beginGroup(PLUGINS_SETTINGS_STORE_GROUP);
+    // The last folder used for saving and opening files
+    m_LastFolderOpen  = settings.value("lastfolderopen", QDir::homePath()).toString();
+    settings.endGroup();
+    
     // Load the available plugin information
     PluginDB *pdb = PluginDB::instance();
     QHash<QString, Plugin *> plugins;
@@ -87,7 +96,7 @@ void PluginWidget::pluginSelected(int row, int col)
 
 void PluginWidget::addPlugin()
 {
-    QString zippath = QFileDialog::getOpenFileName(this, tr("Select Plugin Zip Archive"), "./", tr("Plugin Files (*.zip)"));
+    QString zippath = QFileDialog::getOpenFileName(this, tr("Select Plugin Zip Archive"), m_LastFolderOpen, tr("Plugin Files (*.zip)"));
     if (zippath.isEmpty()) {
         return;
     }
@@ -95,6 +104,14 @@ void PluginWidget::addPlugin()
     PluginDB *pdb = PluginDB::instance();
 
     PluginDB::AddResult ar = pdb->add_plugin(zippath);
+    
+    // Save the last folder used for adding plugin zips
+    m_LastFolderOpen = QFileInfo(zippath).absolutePath();
+    SettingsStore settings;
+    settings.beginGroup(PLUGINS_SETTINGS_STORE_GROUP);
+    settings.setValue("lastfolderopen", m_LastFolderOpen);
+    settings.endGroup();
+    
     switch (ar) {
         case PluginDB::AR_XML:
             Utility::DisplayStdWarningDialog(tr("Error: Plugin plugin.xml file can not be read."));

--- a/src/Sigil/Dialogs/PreferenceWidgets/PluginWidget.h
+++ b/src/Sigil/Dialogs/PreferenceWidgets/PluginWidget.h
@@ -45,6 +45,7 @@ private:
 
     Ui::PluginWidget ui;
     bool m_isDirty;
+    QString m_LastFolderOpen;
 };
 
 #endif // PLUGINWIDGET_H


### PR DESCRIPTION
Hey John,

Been bugging me that the Add Plugin dialog always starts in the same folder, so I (hopefully) made it remember the last folder opened. I also wanted to get the ball rolling on submitting code via github. Don't be afraid to tell me I did all wrong! ;)

Later,

Doug
