### PR TITLE
Changed python3lib scripts to honor dist-package

### DIFF
--- a/src/Resource_Files/python3lib/bs4repair.py
+++ b/src/Resource_Files/python3lib/bs4repair.py
@@ -10,7 +10,7 @@ def insert_into_syspath():
     sp = None
     ourhome = sys.path[-1]
     for apath in sys.path:
-        if apath.endswith("site-packages"):
+        if apath.endswith("site-packages") or apath.endswith("dist-packages"):
             sp = n
             break
         n += 1

--- a/src/Resource_Files/python3lib/xmlprocessor.py
+++ b/src/Resource_Files/python3lib/xmlprocessor.py
@@ -10,7 +10,7 @@ def insert_into_syspath():
     sp = None
     ourhome = sys.path[-1]
     for apath in sys.path:
-        if apath.endswith("site-packages"):
+        if apath.endswith("site-packages") or apath.endswith("dist-packages"):
             sp = n
             break
         n += 1


### PR DESCRIPTION
Installing BeautifulSoup4 locally was breaking Linux system-python builds. The code in bs4repair.py to inject the Sigil (python3lib) bs4 directory into sys.path before any local site modules didn't take into account Linux's "dist-package" site directories--and bs4repair.py wouldn't work with the stock bs4 module.