### PR TITLE
build hunspell and gumbo as shared libraries to allow use by python plugins

### DIFF
--- a/3rdparty/cmake/hunspell.cmake
+++ b/3rdparty/cmake/hunspell.cmake
@@ -23,8 +23,12 @@ SET(SOURCES
     ${PROJECT_NAME}/src/hunspell/replist.cxx
     ${PROJECT_NAME}/src/hunspell/suggestmgr.cxx
 )
+if( APPLE )
+    set(CMAKE_MACOSX_RPATH 1)
+endif()
 
-ADD_LIBRARY(${PROJECT_NAME} ${SOURCES})
+ADD_LIBRARY(${PROJECT_NAME} SHARED ${SOURCES})
+
 target_include_directories(${PROJECT_NAME} PUBLIC
     ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}
     ${CMAKE_CURRENT_SOURCE_DIR}/${PROJECT_NAME}/src/hunspell
@@ -35,5 +39,5 @@ if( MSVC )
     set_target_properties(${PROJECT_NAME} PROPERTIES COMPILE_FLAGS /DHUNSPELL_STATIC)
     set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
 	set( CMAKE_C_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /Oi /GL" ) 
-    set_target_properties( ${PROJECT_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "/LTCG" )
+    # set_target_properties( ${PROJECT_NAME} PROPERTIES STATIC_LIBRARY_FLAGS "/LTCG" )
 endif()

--- a/internal/gumbo/CMakeLists.txt
+++ b/internal/gumbo/CMakeLists.txt
@@ -9,14 +9,18 @@
 
 cmake_minimum_required( VERSION 3.0 ) 
 
-project( gumbo C )
+project( sigilgumbo C )
 
 set( GUMBO_LIBRARIES ${PROJECT_NAME} CACHE INTERNAL "" )
 set( GUMBO_INCLUDE_DIRS ${CMAKE_CURRENT_SOURCE_DIR} CACHE INTERNAL "" )
 
 file( GLOB SOURCES *.c )
 
-add_library( gumbo ${SOURCES} ) 
+if( APPLE )
+        set(CMAKE_MACOSX_RPATH 1)
+endif()
+
+add_library( sigilgumbo SHARED ${SOURCES} ) 
 
 # Special compiler and linker flags for MSVC
 if( MSVC )
@@ -26,7 +30,7 @@ if( MSVC )
 
 	set( CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /MP")
 	set( CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} /Oi /GL" ) 
-	set_target_properties( gumbo PROPERTIES STATIC_LIBRARY_FLAGS "/LTCG" )
+	# set_target_properties( sigilgumbo PROPERTIES STATIC_LIBRARY_FLAGS "/LTCG" )
 endif()
 
 if( UNIX AND NOT APPLE )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -614,6 +614,7 @@ if( APPLE )
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/Sigil.app/Contents/plugin_launchers")
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/Sigil.app/Contents/plugin_launchers/python")
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/Sigil.app/Contents/python3lib")
+        exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/Sigil.app/Contents/lib")
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Release/Sigil.app/Contents/examples")
     else()
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sigil.app/Contents/Resources")
@@ -626,6 +627,7 @@ if( APPLE )
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sigil.app/Contents/plugin_launchers")
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sigil.app/Contents/plugin_launchers/python")
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sigil.app/Contents/python3lib")
+        exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sigil.app/Contents/lib")
         exec_program("mkdir -p ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/Sigil.app/Contents/examples")
     endif()
 
@@ -662,6 +664,7 @@ include_directories( BEFORE
 if ( APPLE )
     add_executable( ${PROJECT_NAME} MACOSX_BUNDLE ${ALL_SOURCES} )
     set_target_properties( ${PROJECT_NAME} PROPERTIES MACOSX_BUNDLE_INFO_PLIST ${PROJECT_BINARY_DIR}/MacOSXBundleInfo.plist )
+    set_target_properties(${PROJECT_NAME} PROPERTIES CMAKE_SKIP_BUILD_RPATH  TRUE)
 # ...and a normal executable for everything else.
 else()
     add_executable( ${PROJECT_NAME} WIN32 ${ALL_SOURCES} )
@@ -760,6 +763,8 @@ if( APPLE )
         add_custom_command( TARGET ${PROJECT_NAME} POST_BUILD COMMAND ${PYTHON_EXECUTABLE} ARGS ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/osx_add_python_framework.py )
     endif()
     add_custom_command( TARGET ${PROJECT_NAME} POST_BUILD COMMAND cp ${CMAKE_SOURCE_DIR}/src/Resource_Files/examples/* ${WORK_DIR}/Sigil.app/Contents/examples )
+    add_custom_command( TARGET ${PROJECT_NAME} POST_BUILD COMMAND cp ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/../lib/*.dylib ${WORK_DIR}/Sigil.app/Contents/lib/ )
+    add_custom_command( TARGET ${PROJECT_NAME} POST_BUILD COMMAND install_name_tool -rpath ${CMAKE_BINARY_DIR}/lib "@executable_path/../lib" ${WORK_DIR}/Sigil.app/Contents/MacOS/Sigil )
  
 # For Linux and Windows, provide binary installers.
 # For this to work on Windows, Inno Setup's iscc compiler needs to be installed and on the system path.


### PR DESCRIPTION
- Rename gumbo lib  to sigilgumbo to prevent name clashes with official gumbo
- Build sigilgumbo as a shared library
- Build hunspell as a shared library
- MacOSX: Create Sigil.app/Contents/lib directory and cp dylibs to it and add proper rpath to Sigil

Note: Still Need to make similar changes for Linux and Windows