### PR TITLE
add initial support for using Spell Checking and BookBrowser Selections in plugins

### DIFF
--- a/src/Dialogs/PluginRunner.cpp
+++ b/src/Dialogs/PluginRunner.cpp
@@ -158,9 +158,9 @@ int PluginRunner::exec(const QString &name)
 
 void PluginRunner::writeSigilCFG()
 {
-  QStringList cfg = QStringList() << QCoreApplication::applicationDirPath();
+    QStringList cfg = QStringList() << QCoreApplication::applicationDirPath();
     cfg << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
-    QList <Resource *> selected_resources = m_bookBrowser->ValidSelectedResources();
+    QList <Resource *> selected_resources = m_bookBrowser->AllSelectedResources();
     foreach(Resource * resource, selected_resources) {
         cfg << resource->GetRelativePathToRoot();
     }

--- a/src/Dialogs/PluginRunner.cpp
+++ b/src/Dialogs/PluginRunner.cpp
@@ -7,6 +7,7 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamAttributes>
 #include <QMessageBox>
+#include <QStandardPaths>
 #include "MainUI/MainWindow.h"
 #include "MainUI/BookBrowser.h"
 #include "Misc/Plugin.h"
@@ -154,6 +155,19 @@ int PluginRunner::exec(const QString &name)
     return QDialog::exec();
 }
 
+
+void PluginRunner::writeSigilCFG()
+{
+  QStringList cfg = QStringList() << QCoreApplication::applicationDirPath();
+    cfg << QStandardPaths::writableLocation(QStandardPaths::DataLocation);
+    QList <Resource *> selected_resources = m_bookBrowser->ValidSelectedResources();
+    foreach(Resource * resource, selected_resources) {
+        cfg << resource->GetRelativePathToRoot();
+    }
+    Utility::WriteUnicodeTextFile(cfg.join("\n"), m_outputDir + "/sigil.cfg");
+}
+
+
 void PluginRunner::startPlugin()
 {
     QStringList args;
@@ -164,6 +178,9 @@ void PluginRunner::startPlugin()
     ui.textEdit->clear();
     ui.textEdit->setOverwriteMode(true);
     ui.textEdit->setPlainText("");
+
+    // create the sigil cfg file in the output directory
+    writeSigilCFG();
 
     // prepare for the plugin by flushing all current book changes to disk
     m_mainWindow->SaveTabData();

--- a/src/Dialogs/PluginRunner.h
+++ b/src/Dialogs/PluginRunner.h
@@ -90,6 +90,9 @@ private:
     bool deleteFiles(const QStringList &);
     bool addFiles(const QStringList &);
     bool modifyFiles(const QStringList &);
+    void writeSigilCFG();
+
+
     void connectSignalsToSlots();
 
     QProcess m_process;

--- a/src/MainUI/BookBrowser.cpp
+++ b/src/MainUI/BookBrowser.cpp
@@ -314,6 +314,57 @@ QList <Resource *> BookBrowser::ValidSelectedResources(Resource::ResourceType re
     return resources;
 }
 
+int BookBrowser::AllSelectedItemCount()
+{
+  QList <QModelIndex> list = m_TreeView->selectionModel()->selectedRows(0);
+  int count = list.length();
+
+  if (count <= 1) {
+    return count;
+  }
+
+  foreach(QModelIndex index, list) {
+    QStandardItem *item = m_OPFModel->itemFromIndex(index);
+    const QString &identifier = item->data().toString();
+
+    // If folder item included, multiple selection is invalid                                                                              
+    if (identifier == NULL) {
+      return -1;
+    }
+
+    Resource *resource = m_Book->GetFolderKeeper()->GetResourceByIdentifier(identifier);
+
+    // If for some reason there is something with an identifier but no resource, fail                                                      
+    if (resource == NULL) {
+      return -1;
+    }
+  }
+  return count;
+}
+
+QList <Resource *> BookBrowser::AllSelectedResources()
+{
+    QList <Resource *> resources;
+    if (AllSelectedItemCount() < 1) {
+        return resources;
+    }
+
+    QList <QModelIndex> list = m_TreeView->selectionModel()->selectedRows(0);
+    foreach(QModelIndex index, list) {
+        QStandardItem *item = m_OPFModel->itemFromIndex(index);
+
+        if (item != NULL) {
+            const QString &identifier = item->data().toString();
+            Resource *resource = m_Book->GetFolderKeeper()->GetResourceByIdentifier(identifier);
+
+            if (resource != NULL) {
+                resources.append(resource);
+            }
+        }
+    }
+    return resources;
+}
+
 QList <Resource *> BookBrowser::ValidSelectedResources()
 {
     QList <Resource *> resources;

--- a/src/MainUI/BookBrowser.h
+++ b/src/MainUI/BookBrowser.h
@@ -69,9 +69,11 @@ public:
     ~BookBrowser();
 
     /**
-     * List of selected resources after validating selection
+     * List of selected resources 
      */
-    QList <Resource *> ValidSelectedResources();
+    QList <Resource *> AllSelectedResources();
+
+    int AllSelectedItemCount();
 
     /**
      * Valid resources selected in the Book Browser
@@ -430,15 +432,20 @@ private:
     void ConnectSignalsToSlots();
 
     /**
-     * List of selected resources after validating selected resources are of the given type
+     * List of selected resources after validating selection
      */
-    QList <Resource *> ValidSelectedResources(Resource::ResourceType resource_type);
-
+    QList <Resource *> ValidSelectedResources();
 
     /**
      * Number of valid items selected
      */
     int ValidSelectedItemCount();
+
+    /**
+     * List of selected resources after validating selected resources are of the given type
+     */
+    QList <Resource *> ValidSelectedResources(Resource::ResourceType resource_type);
+
 
     void RefreshCounts();
 

--- a/src/MainUI/BookBrowser.h
+++ b/src/MainUI/BookBrowser.h
@@ -69,6 +69,11 @@ public:
     ~BookBrowser();
 
     /**
+     * List of selected resources after validating selection
+     */
+    QList <Resource *> ValidSelectedResources();
+
+    /**
      * Valid resources selected in the Book Browser
      */
     QList <Resource *> ValidSelectedHTMLResources();
@@ -423,11 +428,6 @@ private:
      * Connects all the required signals to their respective slots.
      */
     void ConnectSignalsToSlots();
-
-    /**
-     * List of selected resources after validating selection
-     */
-    QList <Resource *> ValidSelectedResources();
 
     /**
      * List of selected resources after validating selected resources are of the given type

--- a/src/Resource_Files/plugin_launchers/python/bookcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/bookcontainer.py
@@ -232,6 +232,7 @@ class BookContainer(object):
     def selected_iter(self):
         # yields id type ('other' or 'manifest') and id/otherid for each file selected in the BookBrowser
         for book_href in self._w.selected:
+            print(book_href)
             id_type = 'other'
             id = book_href
             href = book_href
@@ -252,6 +253,10 @@ class BookContainer(object):
     # create your own current copy of all ebook contents in destintation directory
     def copy_book_contents_to(self, destdir):
         self._w.copy_book_contents_to(destdir)
+
+    # get a list of the directories that contain Sigil's hunspell dictionaries
+    def get_dictionary_dirs(self):
+        return self._w.get_dictionary_dirs()
 
 
     # functions for converting from  manifest id to href, basename, mimetype etc

--- a/src/Resource_Files/plugin_launchers/python/bookcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/bookcontainer.py
@@ -31,6 +31,7 @@ import sys
 import os
 from quickparser import QuickXHTMLParser
 from preferences import JSONPrefs
+from pluginhunspell import HunspellChecker
 
 class ContainerException(Exception):
     pass
@@ -41,6 +42,8 @@ class BookContainer(object):
         self._debug = debug
         self._w = wrapper
         self.qp=QuickXHTMLParser()
+        self.hspell=HunspellChecker(wrapper.get_hunspell_path())
+        self.dictionary_dirs=wrapper.get_dictionary_dirs()
         self._prefs_store = JSONPrefs(wrapper.plugin_dir, wrapper.plugin_name)
 
     def getPrefs(self):
@@ -225,6 +228,19 @@ class BookContainer(object):
         # yields otherid for each file not in the manifest
         for book_href in self._w.other:
             yield book_href
+
+    def selected_iter(self):
+        # yields id type ('other' or 'manifest') and id/otherid for each file selected in the BookBrowser
+        for book_href in self._w.selected:
+            id_type = 'other'
+            id = book_href
+            href = book_href
+            if href.startswith('OEBPS/'):
+                href = href[6:]
+            if href in self._w.href_to_id:
+                id = self._w.href_to_id[href]
+                id_type = 'manifest'
+            yield id_type, id
 
 
     # miscellaneous routines

--- a/src/Resource_Files/plugin_launchers/python/inputcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/inputcontainer.py
@@ -30,6 +30,7 @@ from __future__ import unicode_literals, division, absolute_import, print_functi
 import sys
 import os
 from quickparser import QuickXHTMLParser
+from pluginhunspell import HunspellChecker
 from preferences import JSONPrefs
 
 class ContainerException(Exception):
@@ -41,6 +42,8 @@ class InputContainer(object):
         self._debug = debug
         self._w = wrapper
         self.qp=QuickXHTMLParser()
+        self.hspell=HunspellChecker(wrapper.get_hunspell_path())
+        self.dictionary_dirs=wrapper.get_dictionary_dirs()
         self._prefs_store = JSONPrefs(wrapper.plugin_dir, wrapper.plugin_name)
 
     def getPrefs(self):

--- a/src/Resource_Files/plugin_launchers/python/outputcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/outputcontainer.py
@@ -201,6 +201,11 @@ class OutputContainer(object):
         self._w.copy_book_contents_to(destdir)
 
 
+    # get a list of the directories that contain Sigil's hunspell dictionaries
+    def get_dictionary_dirs(self):
+        return self._w.get_dictionary_dirs()
+
+
     # functions for converting from  manifest id to href, basename, mimetype etc
     def href_to_id(self, href, ow=None):
         return self._w.map_href_to_id(href, ow)

--- a/src/Resource_Files/plugin_launchers/python/outputcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/outputcontainer.py
@@ -31,6 +31,7 @@ import sys
 import os
 from quickparser import QuickXHTMLParser
 from preferences import JSONPrefs
+from pluginhunspell import HunspellChecker
 
 class ContainerException(Exception):
     pass
@@ -41,6 +42,8 @@ class OutputContainer(object):
         self._debug = debug
         self._w = wrapper
         self.qp=QuickXHTMLParser()
+        self.hspell=HunspellChecker(wrapper.get_hunspell_path())
+        self.dictionary_dirs=wrapper.get_dictionary_dirs()
         self._prefs_store = JSONPrefs(wrapper.plugin_dir, wrapper.plugin_name)
 
     def getPrefs(self):
@@ -172,6 +175,19 @@ class OutputContainer(object):
         # yields otherid for each file not in the manifest
         for book_href in self._w.other:
             yield book_href
+
+    def selected_iter(self):
+        # yields id type ('other' or 'manifest') and id/otherid for each file selected in the BookBrowser
+        for book_href in self._w.selected:
+            id_type = 'other'
+            id = book_href
+            href = book_href
+            if href.startswith('OEBPS/'):
+                href = href[6:]
+            if href in self._w.href_to_id:
+                id = self._w.href_to_id[href]
+                id_type = 'manifest'
+            yield id_type, id
 
 
     # miscellaneous routines

--- a/src/Resource_Files/plugin_launchers/python/pluginhunspell.py
+++ b/src/Resource_Files/plugin_launchers/python/pluginhunspell.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# vim:ts=4:sw=4:softtabstop=4:smarttab:expandtab
+
+from __future__ import unicode_literals, division, absolute_import, print_function
+
+import sys
+import os
+from ctypes import *
+import codecs
+
+PY3 = sys.version_info[0] == 3
+if PY3:
+    binary_type = bytes
+    text_type = str
+else:
+    binary_type = str
+    text_type = unicode
+    range = xrange
+
+class HunspellChecker(object):
+
+    def __init__(self, hunspell_dllpath):
+        self.hunhandle = None
+        self.encoder = None
+        self.decoder = None
+        a = c_char_p()
+        p = pointer(a)
+        self.pp = pointer(p)
+        self.retval = 0
+        # ctypes interface to hunspell spellchecker
+        try:
+            self.hunspell = cdll[hunspell_dllpath]
+        except OSError:
+            return None
+        self.hunspell.Hunspell_create.restype = POINTER(c_int)
+        self.hunspell.Hunspell_create.argtypes = (c_char_p, c_char_p)
+        self.hunspell.Hunspell_destroy.argtype = POINTER(c_int)
+        self.hunspell.Hunspell_get_dic_encoding.restype = c_char_p
+        self.hunspell.Hunspell_get_dic_encoding.argtype = POINTER(c_int)
+        self.hunspell.Hunspell_spell.argtypes = (POINTER(c_int), c_char_p)
+        self.hunspell.Hunspell_suggest.argtypes = (POINTER(c_int), POINTER(POINTER(c_char_p)), c_char_p)
+        self.hunspell.Hunspell_free_list.argtypes = (POINTER(c_int), POINTER(POINTER(c_char_p)), c_int)
+
+
+    def loadDictionary(self, affpath, dpath):
+        if type(affpath) == text_type:
+            affpath = affpath.encode('utf-8')
+        if type(dpath) == text_type:
+            dpath = dpath.encode('utf-8')
+        if self.hunhandle is not None:
+            self.cleanUp()
+        self.hunhandle = self.hunspell.Hunspell_create(affpath, dpath)
+        encdic = self.hunspell.Hunspell_get_dic_encoding(self.hunhandle)
+        if type(encdic) == binary_type:
+            encdic = encdic.decode('utf-8')
+        try:
+            self.encoder = codecs.getencoder(encdic)
+            self.decoder = codecs.getdecoder(encdic)
+        except codecs.LookupError:
+            self.encoder = codecs.getencoder('utf-8')
+            self.decoder = codecs.getdecoder('utf-8')
+
+    def cleanUp(self):
+        if self.hunhandle is not None:
+            self.hunspell.Hunspell_destroy(self.hunhandle)
+        self.hunhandle = None
+
+    def encodeit(self, word):
+        encoded_word, encoded_len = self.encoder(word)
+        return encoded_word
+
+    def decodeit(self, word):
+        decoded_word, encoded_len = self.decoder(word)
+        return decoded_word
+
+    def check(self, word):
+        if type(word) == binary_type:
+            word = word.decode('utf-8')
+        return self.hunspell.Hunspell_spell(self.hunhandle, self.encodeit(word))
+
+    def suggest(self,word):
+        if type(word) == binary_type:
+            word = word.decode('utf-8')
+        self.retval = self.hunspell.Hunspell_suggest(self.hunhandle, self.pp, self.encodeit(word))
+        p = self.pp.contents
+        suggestions = []
+        for i in range(0, self.retval):
+             suggestions.append( self.decodeit( c_char_p(p[i]).value ))
+        self.hunspell.Hunspell_free_list(self.hunhandle, self.pp, self.retval)
+        return suggestions
+
+
+def main():
+    checklst = ["hello", "goodbye", "don't", "junkj", "misteak"]
+
+    hunspell_dllpath = "/Users/kbhend/repo/build/bin/Sigil.app/Contents/lib/libhunspell.dylib"
+    hsp = HunspellChecker(hunspell_dllpath)
+
+    if hsp is None:
+        print("Error could not load hunspell shared library", hunspell_dllpath)
+        return 1
+
+    affpath = "/Users/kbhend/repo/build/bin/Sigil.app/Contents/hunspell_dictionaries/en_US.aff"
+    dpath = "/Users/kbhend/repo/build/bin/Sigil.app/Contents/hunspell_dictionaries/en_US.dic"
+
+    hsp.loadDictionary(affpath, dpath)
+
+    for word in checklst:
+        res = hsp.check(word)
+        if res != 1:
+            print(word, "incorrect", hsp.suggest(word))
+        else:
+            print(word, "correct")
+            
+    hsp.cleanUp()
+
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())
+


### PR DESCRIPTION
- increments launcher version
- add support for building sigil.cfg and passing it to launcher
- adds basic support for spell checking in a plugin
- adds basic support for selected_iter (iterator)

To use these new features please see the following plugin.py code examples:

    # To iterate over all files selected in the BookBrowser when the plugin was launched
    for (id_type, id) in bk.selected_iter():
        if id_type == "manifest":
            href = bk.id_to_href(id, ow=None)
            mime = bk.id_to_mime(id, ow=None)
            print(id_type, id, href, mime)
        else:
            print(id_type, id)

    # Example for using hunspell spell checker
    # First search for your desired dictionary among those known to Sigil
    dic_dirs = bk.get_dictionary_dirs();
    afffile = None
    dicfile = None
    for adir in dic_dirs:
        afile = os.path.join(adir, "en_US.aff")
        dfile = os.path.join(adir, "en_US.dic")
        if os.path.exists(afile) and os.path.exists(dfile):
            afffile = afile
            dicfile = dfile
            break
    # If hunspell shared lib was found and specific dictionaries are found then do spell check
    if bk.hspell is not None and afffile is not None and dicfile is not None:
        bk.hspell.loadDictionary(afffile, dicfile)
        checklist =  ["hello", "goodbye", "don't", "junkj", "misteak"]
        for word in checklist:
            res = bk.hspell.check(word)
            if res != 1:
                print(word, "incorrect", bk.hspell.suggest(word))
            else:
                print(word, "correct")    
        bk.hspell.cleanUp()


