### PR TITLE
Ability to choose to use bundled python for plugins

### DIFF
--- a/src/Dialogs/PreferenceWidgets/PluginWidget.h
+++ b/src/Dialogs/PreferenceWidgets/PluginWidget.h
@@ -19,12 +19,15 @@ public:
 
 private slots:
     void addPlugin();
+    bool bundledInterpReady();
+    QString buildBundledInterpPath();
     void AutoFindPy2();
     void AutoFindPy3();
     void SetPy2();
     void SetPy3();
     void enginePy2PathChanged();
     void enginePy3PathChanged();
+    void useBundledPy3Changed(int);
     void removePlugin();
     void removeAllPlugins();
     void pluginSelected(int row, int col);
@@ -46,6 +49,8 @@ private:
     Ui::PluginWidget ui;
     bool m_isDirty;
     QString m_LastFolderOpen;
+    bool m_useBundledInterp;
+    //QString m_bundledInterpPath;
 };
 
 #endif // PLUGINWIDGET_H

--- a/src/Dialogs/PreferenceWidgets/PluginWidget.h
+++ b/src/Dialogs/PreferenceWidgets/PluginWidget.h
@@ -27,6 +27,7 @@ private slots:
     void SetPy3();
     void enginePy2PathChanged();
     void enginePy3PathChanged();
+    void enable_disable_controls();
     void useBundledPy3Changed(int);
     void removePlugin();
     void removeAllPlugins();
@@ -50,7 +51,7 @@ private:
     bool m_isDirty;
     QString m_LastFolderOpen;
     bool m_useBundledInterp;
-    //QString m_bundledInterpPath;
+    QString m_bundledInterpPath;
 };
 
 #endif // PLUGINWIDGET_H

--- a/src/Form_Files/PPluginWidget.ui
+++ b/src/Form_Files/PPluginWidget.ui
@@ -247,7 +247,7 @@
         <bool>false</bool>
        </property>
        <property name="toolTip">
-        <string>Should the bundled Python interpreter be use if present?</string>
+        <string>Should the bundled Python interpreter be used if present?</string>
        </property>
        <property name="text">
         <string>Use Bundled Python</string>

--- a/src/Form_Files/PPluginWidget.ui
+++ b/src/Form_Files/PPluginWidget.ui
@@ -241,6 +241,19 @@
        </property>
       </widget>
      </item>
+     <item row="4" column="2">
+      <widget class="QCheckBox" name="chkUseBundled">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>Should the bundled Python interpreter be use if present?</string>
+       </property>
+       <property name="text">
+        <string>Use Bundled Python</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>

--- a/src/Misc/SettingsStore.cpp
+++ b/src/Misc/SettingsStore.cpp
@@ -51,6 +51,8 @@ static QString KEY_PRESERVE_ENTITY_CODES = SETTINGS_GROUP + "/" + "preserve_enti
 static QString KEY_PLUGIN_INFO = SETTINGS_GROUP + "/" + "plugin_info";
 static QString KEY_PLUGIN_ENGINE_PATHS = SETTINGS_GROUP + "/" + "plugin_engine_paths";
 static QString KEY_PLUGIN_LAST_FOLDER = SETTINGS_GROUP + "/" + "plugin_add_last_folder";
+static QString KEY_PLUGIN_BUNDLED_INTERP_PATH = SETTINGS_GROUP + "/" + "plugin_bundled_interp_path";
+static QString KEY_PLUGIN_USE_BUNDLED_INTERP = SETTINGS_GROUP + "/" + "plugin_use_bundled_interp";
 
 static QString KEY_BOOK_VIEW_FONT_FAMILY_STANDARD = SETTINGS_GROUP + "/" + "book_view_font_family_standard";
 static QString KEY_BOOK_VIEW_FONT_FAMILY_SERIF = SETTINGS_GROUP + "/" + "book_view_font_family_serif";
@@ -227,6 +229,19 @@ QString SettingsStore::pluginLastFolder()
     return value(KEY_PLUGIN_LAST_FOLDER, QDir::homePath()).toString();
 }
 
+QString SettingsStore::bundledInterpPath()
+{
+    clearSettingsGroup();
+    return value(KEY_PLUGIN_BUNDLED_INTERP_PATH, "").toString();
+}
+
+bool SettingsStore::useBundledInterp()
+{
+    clearSettingsGroup();
+    //return value(KEY_PLUGIN_USE_BUNDLED_INTERP, true).toBool();
+    return static_cast<bool>(value(KEY_PLUGIN_USE_BUNDLED_INTERP, false).toBool());
+}
+
 SettingsStore::BookViewAppearance SettingsStore::bookViewAppearance()
 {
     clearSettingsGroup();
@@ -391,6 +406,18 @@ void SettingsStore::setPluginLastFolder(const QString &lastfolder)
 {
     clearSettingsGroup();
     setValue(KEY_PLUGIN_LAST_FOLDER, lastfolder);
+}
+
+void SettingsStore::setBundledInterpPath(const QString &interppath)
+{
+    clearSettingsGroup();
+    setValue(KEY_PLUGIN_BUNDLED_INTERP_PATH, interppath);
+}
+
+void SettingsStore::setUseBundledInterp(bool use)
+{
+    clearSettingsGroup();
+    setValue(KEY_PLUGIN_USE_BUNDLED_INTERP, use);
 }
 
 void SettingsStore::setBookViewAppearance(const SettingsStore::BookViewAppearance &book_view_appearance)

--- a/src/Misc/SettingsStore.cpp
+++ b/src/Misc/SettingsStore.cpp
@@ -238,7 +238,7 @@ QString SettingsStore::bundledInterpPath()
 bool SettingsStore::useBundledInterp()
 {
     clearSettingsGroup();
-    //return value(KEY_PLUGIN_USE_BUNDLED_INTERP, true).toBool();
+    // False if unset. The logic when opening the plugin config widget decides default. 
     return static_cast<bool>(value(KEY_PLUGIN_USE_BUNDLED_INTERP, false).toBool());
 }
 

--- a/src/Misc/SettingsStore.h
+++ b/src/Misc/SettingsStore.h
@@ -100,6 +100,8 @@ public:
      */
     QHash <QString, QString> pluginEnginePaths();
     QString pluginLastFolder();
+    QString bundledInterpPath();
+    bool useBundledInterp();
 
 
     /**
@@ -251,6 +253,8 @@ public slots:
 
     void setPluginEnginePaths(const QHash <QString, QString> &enginepaths);
     void setPluginLastFolder(const QString &lastfolder);
+    void setBundledInterpPath(const QString &interppath);
+    void setUseBundledInterp(bool use);
 
     /**
      * Set whether automatic Spellcheck is enabled


### PR DESCRIPTION
Hey Kevin,

This is what I had in mind with having a checkbox in the Manage Plugins widget to allow the user to control the use of the bundled python vs external python(s). The checkbox is only enabled if the bundled interpreter is present. In which case all the external paths and buttons are disabled (settings retained) and the plugin uses the bundled interpreter if the plugin supports the python3.4 engine.

If no paths external paths are set and the bundled interpreter is available, the checkbox will be checked.

Please don't feel obligated to merge this pull request. I just figured this was the easiest way to to compare my changes to the current master.

Feel free to build from my fork's master branch if you want to see it in action (and to make sure I didn't break anything for OS X)