### PR TITLE
Eliminate need for two EmbeddedPython.cpp files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -304,6 +304,7 @@ set( MISC_FILES
     Misc/PyObjectPtr.h
     Misc/PyObjectPtr.cpp
     Misc/EmbeddedPython.h
+    Misc/EmbeddedPython.cpp
     Misc/GumboInterface.h
     Misc/GumboInterface.cpp
     )
@@ -521,17 +522,11 @@ if ( NOT DEFINED PKG_SYSTEM_PYTHON )
 endif()
 
 if ( PKG_SYSTEM_PYTHON )
-    if ( APPLE )
-        set(MISC_FILES ${MISC_FILES} Misc/EmbeddedPython.cpp)
-    else()
-        set(MISC_FILES ${MISC_FILES} Misc/EmbeddedPythonPkg.cpp)
-    endif()
+    add_definitions( -DBUNDLING_PYTHON )
     if ( MSVC )
-	set_source_files_properties(Misc/EmbeddedPythonPkg.cpp
-                       PROPERTIES COMPILE_FLAGS "/Zc:wchar_t")
+        set_source_files_properties(Misc/EmbeddedPython.cpp
+                    PROPERTIES COMPILE_FLAGS "/Zc:wchar_t")
     endif()
-else()
-    set(MISC_FILES ${MISC_FILES} Misc/EmbeddedPython.cpp)
 endif()
 
 # Default will work for building 32bit Sigil on Windows 32bit and

--- a/src/Dialogs/PluginRunner.cpp
+++ b/src/Dialogs/PluginRunner.cpp
@@ -203,10 +203,16 @@ void PluginRunner::startPlugin()
         // -O Basic Optimization (also changes the bytecode file extension from .pyc to .pyo)
         // -B Don't write bytecode
         // -u sets python for unbuffered io
-        args.append(QString("-EOBu")); 
+#ifdef Q_OS_MAC
+        args.append(QString("-Eu"));
+#elif defined(Q_OS_WIN32)
+        args.append(QString("-EOBu"));
+#elif !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
+        args.append(QString("-EOBu"));
+#endif
     }
     else {
-        args.append(QString("-Bu"));
+        args.append(QString("-u"));
     }
     args.append(QDir::toNativeSeparators(m_launcherPath));
     args.append(QDir::toNativeSeparators(m_bookRoot));

--- a/src/Dialogs/PreferenceWidgets/PluginWidget.cpp
+++ b/src/Dialogs/PreferenceWidgets/PluginWidget.cpp
@@ -296,11 +296,11 @@ void PluginWidget::SetPy3()
 
 void PluginWidget::enable_disable_controls()
 {
-    ui.editPathPy2->setEnabled(!m_useBundledInterp);
+    // ui.editPathPy2->setEnabled(!m_useBundledInterp);
     ui.editPathPy3->setEnabled(!m_useBundledInterp);
-    ui.Py2Auto->setEnabled(!m_useBundledInterp);
+    // ui.Py2Auto->setEnabled(!m_useBundledInterp);
     ui.Py3Auto->setEnabled(!m_useBundledInterp);
-    ui.Py2Set->setEnabled(!m_useBundledInterp);
+    // ui.Py2Set->setEnabled(!m_useBundledInterp);
     ui.Py3Set->setEnabled(!m_useBundledInterp);
 }
 

--- a/src/Misc/EmbeddedPython.cpp
+++ b/src/Misc/EmbeddedPython.cpp
@@ -192,11 +192,12 @@ EmbeddedPython::EmbeddedPython()
     pysyspath.toWCharArray(mpath);
     mpath[pysyspath.size()]=L'\0';
     delete[] hpath;
+
+    Py_OptimizeFlag = 2;
+    Py_DontWriteBytecodeFlag = 1;
 #endif // !defined(__APPLE__)
     // Everyone uses these flags when python is bundled.
-    Py_OptimizeFlag = 2;
     Py_NoSiteFlag = 1;
-    Py_DontWriteBytecodeFlag = 1;
     Py_IgnoreEnvironmentFlag = 1;
     Py_NoUserSiteDirectory = 1;
     //Py_DebugFlag = 0;


### PR DESCRIPTION
Never liked the messy EmbeddedPython vs EmbeddedPythonPkg situation so I combined them into one. Had Cmake issue a preprocessor directive that EmbeddedPython.cpp can use to determine if python is being bundled or not at compile time. Also made a cosmetic change to PluginWidget.cpp: No need to disable the python2 controls when the "Use Bundled Python" is checked. It might lead people to believe they can't use python2 plugins when they're disabled.