### PR TITLE
preserve last opened file name

### DIFF
--- a/src/MainUI/MainWindow.cpp
+++ b/src/MainUI/MainWindow.cpp
@@ -769,6 +769,8 @@ bool MainWindow::SaveAs()
 
     // Store the folder the user saved to
     m_LastFolderOpen = QFileInfo(filename).absolutePath();
+    // Store new filename
+    m_CurrentFileName=QFileInfo(filename).fileName();
     bool save_result = SaveFile(filename);
 
     if (!save_result) {
@@ -3341,6 +3343,7 @@ void MainWindow::CreateNewBook()
     SetNewBook(new_book);
     new_book->SetModified(false);
     m_SaveACopyFilename = "";
+    m_CurrentFileName.clear();
     UpdateUiWithCurrentFile("");
 }
 
@@ -3392,6 +3395,8 @@ bool MainWindow::LoadFile(const QString &fullfilepath, bool is_internal)
                 ShowLastOpenFileWarnings();
             }
 
+            //preserve file name
+            m_CurrentFileName=QFileInfo(fullfilepath).fileName();
             if (!is_internal) {
                 // Store the folder the user opened from
                 m_LastFolderOpen = QFileInfo(fullfilepath).absolutePath();
@@ -3678,7 +3683,9 @@ const QMap<QString, QString> MainWindow::GetSaveFiltersMap()
 void MainWindow::UpdateUiWithCurrentFile(const QString &fullfilepath)
 {
     m_CurrentFilePath = fullfilepath;
-    m_CurrentFileName = m_CurrentFilePath.isEmpty() ? DEFAULT_FILENAME : QFileInfo(m_CurrentFilePath).fileName();
+    if(m_CurrentFileName.isEmpty()){
+        m_CurrentFileName = DEFAULT_FILENAME;
+    }
     // Update the titlebar
     setWindowTitle(tr("%1[*] - %2").arg(m_CurrentFileName).arg(tr("Sigil")));
 


### PR DESCRIPTION
I was elsewhere doing something different. Now I do some books again. Hence this.
This patch was rejected by user none for his design(?) reasons.
So here it is again: let Sigil remember last read file name - even though it comes from plugin - and offer it as a file name when "Save" or "Save As" is invoked.
