### PR TITLE
Compress whitespace in header text in TOC generation.

### DIFF
--- a/src/Dialogs/HeadingSelector.cpp
+++ b/src/Dialogs/HeadingSelector.cpp
@@ -619,7 +619,8 @@ void HeadingSelector::CreateTOCModel()
 void HeadingSelector::InsertHeadingIntoModel(Headings::Heading &heading, QStandardItem *parent_item)
 {
     Q_ASSERT(parent_item);
-    QString heading_text = !heading.title.isNull() ? heading.title : heading.text;
+    // Compress whitespace that pretty-print may add inside of header text.
+    QString heading_text = !heading.title.isNull() ? heading.title : heading.text.simplified();
     QStandardItem *item_heading           = new QStandardItem(heading_text);
     QStandardItem *heading_level          = new QStandardItem("h" % QString::number(heading.level));
     QStandardItem *heading_included_check = new QStandardItem();

--- a/src/Exporters/NCXWriter.cpp
+++ b/src/Exporters/NCXWriter.cpp
@@ -237,7 +237,8 @@ void NCXWriter::WriteNavPoint(const NCXModel::NCXEntry &entry, int &play_order)
     m_Writer->writeAttribute("playOrder", QString("%1").arg(play_order));
     play_order++;
     m_Writer->writeStartElement("navLabel");
-    m_Writer->writeTextElement("text", entry.text);
+    // Compress whitespace that pretty-print may add.
+    m_Writer->writeTextElement("text", entry.text.simplified());
     m_Writer->writeEndElement();
     m_Writer->writeEmptyElement("content");
     m_Writer->writeAttribute("src", entry.target);

--- a/src/MainUI/NCXModel.cpp
+++ b/src/MainUI/NCXModel.cpp
@@ -155,7 +155,8 @@ NCXModel::NCXEntry NCXModel::ParseNavPoint(QXmlStreamReader &ncx)
 
                 // The string returned from text() is unescaped
                 // (that is, XML entities have already been converted to text).
-                current.text = ncx.text().toString();
+                // Compress whitespace that pretty-print may add.
+                current.text = ncx.text().toString().simplified();
             } else if (ncx.name() == "content") {
                 current.target = Utility::URLDecodePath(ncx.attributes().value("", "src").toString());
             } else if (ncx.name() == "navPoint") {


### PR DESCRIPTION
See what you think of this Kevin.

I can't see any reason for line-feeds inside of header-text (generated by pretty-print) to be displayed/included in:

    1) The table of contents widget
    2) the header selection dialog when generating a ToC
    3) the navLabel text entry in the NCX file

So I've compressed whitespace in the header text in three locations using Qt's QString::simplified().

I was looking for one single place where I could compress the whitespace when the header texts are first rounded up, but I couldn't seem to find where to do it.

Anyway ... see if this even makes sense to you (and make sure it doesn't break anything else) and get back to me on it.