### PR TITLE
Switch TempFolder to QTemporaryDir

### DIFF
--- a/src/Misc/TempFolder.h
+++ b/src/Misc/TempFolder.h
@@ -24,6 +24,7 @@
 #define TEMPFOLDER_H
 
 #include <QtCore/QString>
+#include <QtCore/QTemporaryDir>
 
 /**
  * A RAII wrapper around a temp folder. Creating an object of this
@@ -70,12 +71,12 @@ private:
     TempFolder(const TempFolder &);
 
     /**
-     * Provides a full path to a new temp folder.
-     * It is the callers responsibility to create the folder.
+     * Provides the template for QTemporaryDir for new temporary
+     * folders.
      *
-     * @return Full path to a new temp folder.
+     * @return Absolute path to a new temp folder template.
      */
-    static QString GetNewTempFolderPath();
+    static QString GetNewTempFolderTemplate();
 
     /**
      * Deletes the folder specified and all the files
@@ -94,7 +95,7 @@ private:
     /**
      * The full path to the temp folder.
      */
-    QString m_PathToFolder;
+    QTemporaryDir m_tempDir;
 };
 
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -189,19 +189,6 @@ void MessageHandler(QtMsgType type, const QMessageLogContext &context, const QSt
 }
 
 
-/**
- * Creates (or modifies, if it already exists) the Sigil temp folder so that it
- * can be read and modified by anyone.
- */
-void CreateTempFolderWithCorrectPermissions()
-{
-    QString temp_path = TempFolder::GetPathToSigilScratchpad();
-    QDir(temp_path).mkpath(temp_path);
-    QFile::setPermissions(temp_path, QFile::ReadOwner | QFile::WriteOwner | QFile::ExeOwner |
-                          QFile::ReadGroup | QFile::WriteGroup | QFile::ExeGroup |
-                          QFile::ReadOther | QFile::WriteOther | QFile::ExeOther);
-}
-
 void VerifyPlugins()
 {
     PluginDB *pdb = PluginDB::instance();
@@ -257,12 +244,6 @@ int main(int argc, char *argv[])
         // and on Mac by the ICNS file.
 #if !defined(Q_OS_WIN32) && !defined(Q_OS_MAC)
         app.setWindowIcon(GetApplicationIcon());
-#endif
-        // On Unix systems, we make sure that the temp folder we
-        // create is accessible by all users. On Windows, there's
-        // a temp folder per user.
-#ifndef Q_OS_WIN32
-        CreateTempFolderWithCorrectPermissions();
 #endif
         // Needs to be created on the heap so that
         // the reply has time to return.


### PR DESCRIPTION
Refactor `TempFolder` to use `QTemporaryDir` internally, instead of manually creating directories ourselves (which is not race-free). `QTemporaryDir` gives us a race-free temporary directory, which is also cleaned automatically (albeit synchronously) on `~QTemporaryDir`.

The extra hierarchy (`Sigil/scratchpad`) in the system temporary directory is no more used, as the result now is unique enough, and not shared by all the users on the same machine. As a consequence, there is no more need to fix the permissions of the scratchpad.