### PR TITLE
Updated Transifex project URL

### DIFF
--- a/docs/Translating.md
+++ b/docs/Translating.md
@@ -9,7 +9,7 @@ Web Tools
 =========
 
 Sigil can be translated using the web based translation system Transifex. See
-https://www.transifex.net/projects/p/sigil/ . This is the preferred method for
+https://www.transifex.com/zdpo/sigil/ . This is the preferred method for
 translating Sigil.
 
 


### PR DESCRIPTION
The existing Transifex URL in Translating.md is outdated and leads to hxxps://www.transifex.net which uses a certificate expired in 2013 and then redirects to the current URL. Updated to directly point to the correct Transifex project URL.