### PR TITLE
Modify W3C CSS validation tool

### DIFF
--- a/src/Dialogs/PreferenceWidgets/GeneralSettingsWidget.cpp
+++ b/src/Dialogs/PreferenceWidgets/GeneralSettingsWidget.cpp
@@ -36,6 +36,7 @@ PreferencesWidget::ResultAction GeneralSettingsWidget::saveSettings()
 
     int new_clean_on_level = 0;
     QString new_epub_version = "2.0";
+    QString css_epub2_spec = "css21";
 
     if (ui.EpubVersion3->isChecked()) {
         new_epub_version = "3.0";
@@ -45,6 +46,12 @@ PreferencesWidget::ResultAction GeneralSettingsWidget::saveSettings()
     }
     if (ui.MendOnSave->isChecked()) {
         new_clean_on_level |= CLEANON_SAVE;
+    }
+    if (ui.Epub2css21->isChecked()) {
+        css_epub2_spec = "css21";
+    }
+    if (ui.Epub2css30->isChecked()) {
+        css_epub2_spec = "css30";
     }
 
     int new_remote_on_level = 0;
@@ -56,6 +63,7 @@ PreferencesWidget::ResultAction GeneralSettingsWidget::saveSettings()
     SettingsStore settings;
     settings.setCleanOn(new_clean_on_level);
     settings.setDefaultVersion(new_epub_version);
+    settings.setCssEpub2ValidationSpec(css_epub2_spec);
     settings.setRemoteOn(new_remote_on_level);
     return PreferencesWidget::ResultAction_None;
 }
@@ -64,8 +72,11 @@ void GeneralSettingsWidget::readSettings()
 {
     SettingsStore settings;
     QString version = settings.defaultVersion();
+    QString css_epub2_spec = settings.cssEpub2ValidationSpec();
     ui.EpubVersion2->setChecked(version == "2.0");
     ui.EpubVersion3->setChecked(version == "3.0");
+    ui.Epub2css21->setChecked(css_epub2_spec == "css21");
+    ui.Epub2css30->setChecked(css_epub2_spec == "css30");
     int cleanOn = settings.cleanOn();
     ui.MendOnOpen->setChecked(cleanOn & CLEANON_OPEN);
     ui.MendOnSave->setChecked(cleanOn & CLEANON_SAVE);

--- a/src/Form_Files/PGeneralSettingsWidget.ui
+++ b/src/Form_Files/PGeneralSettingsWidget.ui
@@ -7,25 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>383</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>General Settings</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>6</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item>
     <widget class="QGroupBox" name="groupBox">
      <property name="toolTip">
@@ -107,7 +95,7 @@ and when switching from Book View to Code View.</string>
      <property name="title">
       <string> Control Access by Epubs to non-multimedia remote resources.</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout2">
+     <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0">
        <widget class="QCheckBox" name="AllowRemote">
         <property name="toolTip">
@@ -125,14 +113,52 @@ and when switching from Book View to Code View.</string>
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="groupBox_4">
+     <property name="toolTip">
+      <string>What CSS spec to specify for W3C validation</string>
+     </property>
+     <property name="title">
+      <string>EPUB2 CSS Validation Specification:</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QRadioButton" name="Epub2css21">
+        <property name="toolTip">
+         <string>Validate with CSS 2.1</string>
+        </property>
+        <property name="text">
+         <string>CSS 2.1</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QRadioButton" name="Epub2css30">
+        <property name="toolTip">
+         <string>Validate with CSS 3.0</string>
+        </property>
+        <property name="text">
+         <string>CSS 3.0</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>40</width>
-       <height>20</height>
+       <width>20</width>
+       <height>40</height>
       </size>
      </property>
     </spacer>

--- a/src/Misc/SettingsStore.cpp
+++ b/src/Misc/SettingsStore.cpp
@@ -56,6 +56,9 @@ static QString KEY_PLUGIN_ENGINE_PATHS = SETTINGS_GROUP + "/" + "plugin_engine_p
 static QString KEY_PLUGIN_LAST_FOLDER = SETTINGS_GROUP + "/" + "plugin_add_last_folder";
 static QString KEY_PLUGIN_USE_BUNDLED_INTERP = SETTINGS_GROUP + "/" + "plugin_use_bundled_interp";
 
+static QString KEY_CSS_EPUB2_VALIDATION_SPEC = SETTINGS_GROUP + "/" + "css_epub2_validation_spec";
+static QString KEY_CSS_EPUB3_VALIDATION_SPEC = SETTINGS_GROUP + "/" + "css_epub3_validation_spec";
+
 static QString KEY_BOOK_VIEW_FONT_FAMILY_STANDARD = SETTINGS_GROUP + "/" + "book_view_font_family_standard";
 static QString KEY_BOOK_VIEW_FONT_FAMILY_SERIF = SETTINGS_GROUP + "/" + "book_view_font_family_serif";
 static QString KEY_BOOK_VIEW_FONT_FAMILY_SANS_SERIF = SETTINGS_GROUP + "/" + "book_view_font_family_sans_serif";
@@ -240,6 +243,18 @@ bool SettingsStore::useBundledInterp()
     return static_cast<bool>(value(KEY_PLUGIN_USE_BUNDLED_INTERP, true).toBool());
 }
 
+QString SettingsStore::cssEpub2ValidationSpec()
+{
+    clearSettingsGroup();
+    return value(KEY_CSS_EPUB2_VALIDATION_SPEC, "css21").toString();
+}
+
+QString SettingsStore::cssEpub3ValidationSpec()
+{
+    clearSettingsGroup();
+    return value(KEY_CSS_EPUB3_VALIDATION_SPEC, "css30").toString();
+}
+
 SettingsStore::BookViewAppearance SettingsStore::bookViewAppearance()
 {
     clearSettingsGroup();
@@ -422,6 +437,18 @@ void SettingsStore::setUseBundledInterp(bool use)
 {
     clearSettingsGroup();
     setValue(KEY_PLUGIN_USE_BUNDLED_INTERP, use);
+}
+
+void SettingsStore::setCssEpub2ValidationSpec(const QString &spec)
+{
+    clearSettingsGroup();
+    setValue(KEY_CSS_EPUB2_VALIDATION_SPEC, spec);
+}
+
+void SettingsStore::setCssEpub3ValidationSpec(const QString &spec)
+{
+    clearSettingsGroup();
+    setValue(KEY_CSS_EPUB3_VALIDATION_SPEC, spec);
 }
 
 void SettingsStore::setBookViewAppearance(const SettingsStore::BookViewAppearance &book_view_appearance)

--- a/src/Misc/SettingsStore.h
+++ b/src/Misc/SettingsStore.h
@@ -95,6 +95,11 @@ public:
     QString pluginLastFolder();
     bool useBundledInterp();
 
+    /**
+     * Get version specification for W3C validation
+     */
+    QString cssEpub2ValidationSpec();
+    QString cssEpub3ValidationSpec();
 
     /**
      * Whether automatic Spellcheck is enabled or not
@@ -250,6 +255,12 @@ public slots:
     void setPluginEnginePaths(const QHash <QString, QString> &enginepaths);
     void setPluginLastFolder(const QString &lastfolder);
     void setUseBundledInterp(bool use);
+
+    /**
+     * Set which css version to specify to the W3C Validator
+     */
+    void setCssEpub2ValidationSpec(const QString &spec);
+    void setCssEpub3ValidationSpec(const QString &spec);
 
     /**
      * Set whether automatic Spellcheck is enabled

--- a/src/ResourceObjects/CSSResource.cpp
+++ b/src/ResourceObjects/CSSResource.cpp
@@ -25,6 +25,7 @@
 #include <QtGui/QDesktopServices>
 
 #include "Misc/Utility.h"
+#include "Misc/SettingsStore.h"
 #include "ResourceObjects/CSSResource.h"
 
 static const QString W3C_HTML_FORM = "<html>"
@@ -37,7 +38,7 @@ static const QString W3C_HTML_FORM = "<html>"
                                      "   <form id='form' enctype='multipart/form-data' action='http://jigsaw.w3.org/css-validator/validator' method='post'>"
                                      "    <p><textarea name='text' rows='12' cols='70'>%4</textarea></p>"
                                      "    <input type='hidden' name='lang' value='en' />"
-                                     "    <input type='hidden' name='profile' value='css21' />"
+                                     "    <input type='hidden' name='profile' value='%5' />"
                                      "   </form>"
                                      "  </div>"
                                      "  <script type='text/javascript'>"
@@ -83,11 +84,24 @@ Resource::ResourceType CSSResource::Type() const
 
 void CSSResource::ValidateStylesheetWithW3C()
 {
+    SettingsStore settings;
+    QString spec;
+
+    // use css 3.0 for EPUB3 W3C validation.
+    // check user prefs for EPUB2 CSS spec
+    if (GetEpubVersion().startsWith('3')) {
+        spec = settings.cssEpub3ValidationSpec();
+    }
+    else {
+        spec = settings.cssEpub2ValidationSpec();
+    }
+
     const QString &post_form_html = W3C_HTML_FORM
                                     .arg(tr("Sigil will send your stylesheet data to the <a href='http://jigsaw.w3.org/css-validator/'>W3C Validation Service</a>."))
                                     .arg(tr("This page should disappear once loaded after 3 seconds."))
                                     .arg(tr("If your browser does not have javascript enabled, click on the button below."))
-                                    .arg(GetText());
+                                    .arg(GetText())
+                                    .arg(spec);
     const QString &temp_file_path = Utility::GetTemporaryFileNameWithExtension(".html");
     Utility::WriteUnicodeTextFile(post_form_html, temp_file_path);
     m_TemporaryValidationFiles.append(temp_file_path);


### PR DESCRIPTION
EPUB3 always validates using CSS 3.0. EPUB2 validates using user choice (CSS 2.1 or CSS 3.0) in General preferences (defaults to CSS 2.1). SettingsStore entries are in place to make EPUB3 validation a user preference as well, but is unimplemented currently.