### PR TITLE
Typo in href_to_basename

### DIFF
--- a/src/Resource_Files/plugin_launchers/python/bookcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/bookcontainer.py
@@ -312,7 +312,7 @@ class BookContainer(object):
         return self._w.map_id_to_href(id, ow)
 
     def href_to_basename(self, href, ow=None):
-        if basename is not None:
+        if href is not None:
             return href.split('/')[-1]
         return ow
 


### PR DESCRIPTION
This is simply a typo, I think. With 'href' the function works properly.