### PR TITLE
Instruct sigil to look up a couple of path by default on linux for dictionaries

### DIFF
--- a/src/Misc/SpellCheck.cpp
+++ b/src/Misc/SpellCheck.cpp
@@ -342,11 +342,16 @@ void SpellCheck::loadDictionaryNames()
         }
     }
     // else use the env var runtime overridden 'share/sigil/hunspell_dictionaries/' location.
-    else if (!sigil_extra_root.isEmpty()) {
-        paths.append(sigil_extra_root + "/hunspell_dictionaries/");
-    } else {
-        // else use the standard build time 'share/sigil/hunspell_dictionaries/'location.
-        paths.append(sigil_share_root + "/hunspell_dictionaries/");
+    else {
+        if (!sigil_extra_root.isEmpty()) {
+            paths.append(sigil_extra_root + "/hunspell_dictionaries/");
+        } else {
+            // prepend the usual places where hunspell dictionaries are located in unix systems
+            paths.append("/usr/share/myspell/");
+            paths.append("/usr/share/hunspell/");
+            // else use the standard build time 'share/sigil/hunspell_dictionaries/'location.
+            paths.append(sigil_share_root + "/hunspell_dictionaries/");
+        }
     }
 #endif
     // Add the user dictionary directory last because anything in here

--- a/src/Resource_Files/plugin_launchers/python/wrapper.py
+++ b/src/Resource_Files/plugin_launchers/python/wrapper.py
@@ -828,11 +828,14 @@ class Wrapper(object):
                 if len(share_override):
                     apaths.append(unipath.abspath(os.path.join(share_override, "hunspell_dictionaries")))
                 else:
+                    # prepend usual places where hunspell dictionaries are located in unix systems
+                    apaths.append(os.path.join(os.sep, 'usr', 'share', 'myspell')
+                    apaths.append(os.path.join(os.sep, 'usr', 'share', 'hunspell')
                     # Otherwise, use Sigil's bundled hunspell dictionary location.
                     apaths.append(unipath.abspath(os.path.join(share_prefix, "share", 'sigil', "hunspell_dictionaries")))
             apaths.append(unipath.abspath(os.path.join(self.usrsupdir,"hunspell_dictionaries")))
         return apaths
-                        
+
     def get_gumbo_path(self):
         if sys.platform.startswith('darwin'):
             lib_dir = unipath.abspath(os.path.join(self.appdir,"..","lib"))
@@ -844,7 +847,7 @@ class Wrapper(object):
             lib_dir = unipath.abspath(self.appdir)
             lib_name = 'libsigilgumbo.so'
         return os.path.join(lib_dir, lib_name)
-            
+
     def get_hunspell_path(self):
         if sys.platform.startswith('darwin'):
             lib_dir = unipath.abspath(os.path.join(self.appdir,"..","lib"))


### PR DESCRIPTION
add /usr/share/hunspell/ and /usr/share/myspell/ to the used paths.

Those are the paths where spelling dictionaries are installed on most linux
distributions.

Used only when neither SIGIL_DICTIONARIES nor SIGIL_EXTRA_ROOT are set.


Would you be open to this kind of change?
The aim is to drop the patch in the loader that is just setting SIGIL_DICTIONARIES, when sigil could look up that path by itself.  FYI, libreoffice defaults on /usr/share/hunspell (and falls back to /usr/share/myspell if the former doesn't exists) and it's used on debian and derivatives (where we are deprecating /usr/share/myspell); whereas /usr/share/myspell is used on redhat and derivatives, and apparently /u/s/hunspell doesn't exist anywhere.  Also scribus started to look up these paths by itself in the recent 1.5.2 development release.