### PR TITLE
Fix UI language setting resetting back to English

### DIFF
--- a/src/Dialogs/PreferenceWidgets/LanguageWidget.cpp
+++ b/src/Dialogs/PreferenceWidgets/LanguageWidget.cpp
@@ -84,7 +84,7 @@ void LanguageWidget::readSettings()
 
     ui.cbMetadataLanguage->setCurrentIndex(index);
     // UI Language
-    index = ui.cbUILanguage->findText(Language::instance()->GetLanguageName(settings.uiLanguage()));
+    index = ui.cbUILanguage->findText(Language::instance()->GetLanguageName(settings.uiLanguage().replace("_", "-")));
 
     if (index == -1) {
         index = ui.cbUILanguage->findText(Language::instance()->GetLanguageName("en"));


### PR DESCRIPTION
When the language code contains "-". The setting is saved with "-" replaced to "_", but this was not changed back when dialog was loaded.