### PR TITLE
Implemented user dictionaries / ignored words, numerous tweaks 

### DIFF
--- a/src/Dialogs/PreferenceWidgets/SpellCheckWidget.h
+++ b/src/Dialogs/PreferenceWidgets/SpellCheckWidget.h
@@ -57,15 +57,25 @@ private slots:
     void dictionariesCurrentIndexChanged(int index);
     void checkBoxChanged(int state);
     void ItemChanged(QStandardItem *item);
+    void tabChanged(int tab);
 
 private:
     void setUpTable();
     void setDefaultUserDictionary(QString dict_name = QString());
-    bool createUserDict(QString dict_name);
+    bool createUserDict(const QStringList dict_name);
+    bool copyDicWithSubdics(const QString &source, const QStringList &destination);
 
     QStringList EnabledDictionaries();
 
     void addNewItem(bool enabled, QString dict_name);
+    void addNewMLItem(bool enabled, QStringList dicts);
+
+    QStandardItem * getParent(const QModelIndex selected);
+    QStandardItem * getSelected(const QModelIndex selected);
+    QString getSelectedDictName(const QModelIndex selected);
+    QString getSelectedParentDic(const QModelIndex selected);
+    QStringList getChildrenDics(const QModelIndex selected);
+    void dictionaryDirty(const QString userDict, const bool force=false);
 
     void readSettings();
     void connectSignalsToSlots();
@@ -73,7 +83,10 @@ private:
     Ui::SpellCheckWidget ui;
     bool m_isDirty;
 
-    QStandardItemModel m_Model;
+    QByteArray m_hash;
+    QStringList m_dirtyDicts;
+    QStandardItemModel *m_Model;
 };
+
 
 #endif // SPELLCHECKWIDGET_H

--- a/src/Dialogs/SpellcheckEditor.h
+++ b/src/Dialogs/SpellcheckEditor.h
@@ -92,6 +92,7 @@ private slots:
     void Sort(int logicalindex, Qt::SortOrder order);
 
 //******varlogs
+    void IgnoreML();
     const QString choseDictionary();
     void loadDictionary();
     void loadDictionary(const QString lang);

--- a/src/Form_Files/PSpellCheckWidget.ui
+++ b/src/Form_Files/PSpellCheckWidget.ui
@@ -286,13 +286,22 @@ You cannot remove the last dictionary.</string>
                </layout>
               </item>
               <item>
-               <widget class="QTableView" name="userDictList">
+               <widget class="QTreeView" name="userDictList">
+                <property name="mouseTracking">
+                 <bool>true</bool>
+                </property>
                 <property name="toolTip">
                  <string>Mark which dictionaries are enabled for
 spell checking.
 
 Select a dictionary to display its words,
 and to make it the default dictionary.</string>
+                </property>
+                <property name="uniformRowHeights">
+                 <bool>true</bool>
+                </property>
+                <property name="animated">
+                 <bool>true</bool>
                 </property>
                </widget>
               </item>

--- a/src/MainUI/MainWindow.cpp
+++ b/src/MainUI/MainWindow.cpp
@@ -3341,10 +3341,10 @@ void MainWindow::MendHTML()
 
 void MainWindow::ClearIgnoredWords()
 {
-    QApplication::setOverrideCursor(Qt::WaitCursor);
     SpellCheck *sc = SpellCheck::instance();
-    sc->clearIgnoredWords();
+    sc->clearAllMLIgnoredWords();
     // Need to reload any tabs to force spelling to be run again in CodeView
+    QApplication::setOverrideCursor(Qt::WaitCursor);
     RefreshSpellingHighlighting();
     QApplication::restoreOverrideCursor();
 }
@@ -3605,7 +3605,7 @@ void MainWindow::SetNewBook(QSharedPointer<Book> new_book)
     //because it calls in the end QuickSerialHtmlParser
     SpellCheck *sc = SpellCheck::instance();
     sc->setDCLanguages(m_Book->getBookMainDCLanguageCodes());
-    sc->clearIgnoredWords();
+    sc->clearAllMLIgnoredWords();
     m_BookBrowser->SetBook(m_Book);
     m_TableOfContents->SetBook(m_Book);
     m_ValidationResultsView->SetBook(m_Book);

--- a/src/Misc/HTMLSpellCheck.h
+++ b/src/Misc/HTMLSpellCheck.h
@@ -75,7 +75,6 @@ public:
 
     static int WordPosition(QString text, QString word, int start_pos);
 
- //***varlogs
     static int WordPosition(QString text, QString word, QString lang, int start_pos);
     static QList<MisspelledWord> GetMLMisspelledWords(const QString &text,
             int start_offset,

--- a/src/Misc/SearchOperations.cpp
+++ b/src/Misc/SearchOperations.cpp
@@ -202,30 +202,30 @@ std::tuple<QString, int> SearchOperations::PerformGlobalReplace(const QString &t
 }
 
 
-std::tuple<QString, int> SearchOperations::PerformHTMLSpellCheckReplace(const QString &text,
-        const QString &search_regex,
-        const QString &replacement)
-{
-    QString new_text = text;
-    int count = 0;
-    int offset = 0;
-    SPCRE *spcre = PCRECache::instance()->getObject(search_regex);
-    QList<HTMLSpellCheck::MisspelledWord> check_spelling = HTMLSpellCheck::GetMisspelledWords(text, 0, text.count(), search_regex);
-    foreach(HTMLSpellCheck::MisspelledWord misspelled_word, check_spelling) {
-        SPCRE::MatchInfo match_info = spcre->getFirstMatchInfo(misspelled_word.text);
+//std::tuple<QString, int> SearchOperations::PerformHTMLSpellCheckReplace(const QString &text,
+//        const QString &search_regex,
+//        const QString &replacement)
+//{
+//    QString new_text = text;
+//    int count = 0;
+//    int offset = 0;
+//    SPCRE *spcre = PCRECache::instance()->getObject(search_regex);
+//    QList<HTMLSpellCheck::MisspelledWord> check_spelling = HTMLSpellCheck::GetMisspelledWords(text, 0, text.count(), search_regex);
+//    foreach(HTMLSpellCheck::MisspelledWord misspelled_word, check_spelling) {
+//        SPCRE::MatchInfo match_info = spcre->getFirstMatchInfo(misspelled_word.text);
 
-        if (match_info.offset.first != -1) {
-            QString replacement_text;
+//        if (match_info.offset.first != -1) {
+//            QString replacement_text;
 
-            if (spcre->replaceText(Utility::Substring(match_info.offset.first, match_info.offset.second, misspelled_word.text), match_info.capture_groups_offsets, replacement, replacement_text)) {
-                new_text.replace(offset + misspelled_word.offset + match_info.offset.first, match_info.offset.second - match_info.offset.first, replacement_text);
-                offset += replacement_text.length() - (match_info.offset.second - match_info.offset.first);
-                count++;
-            }
-        }
-    }
-    return std::make_tuple(new_text, count);
-}
+//            if (spcre->replaceText(Utility::Substring(match_info.offset.first, match_info.offset.second, misspelled_word.text), match_info.capture_groups_offsets, replacement, replacement_text)) {
+//                new_text.replace(offset + misspelled_word.offset + match_info.offset.first, match_info.offset.second - match_info.offset.first, replacement_text);
+//                offset += replacement_text.length() - (match_info.offset.second - match_info.offset.first);
+//                count++;
+//            }
+//        }
+//    }
+//    return std::make_tuple(new_text, count);
+//}
 
 
 void SearchOperations::Accumulate(int &first, const int &second)

--- a/src/Misc/SearchOperations.h
+++ b/src/Misc/SearchOperations.h
@@ -89,9 +89,9 @@ private:
             const QString &search_regex,
             const QString &replacement);
 
-    static std::tuple<QString, int> PerformHTMLSpellCheckReplace(const QString &text,
-            const QString &search_regex,
-            const QString &replacement);
+//    static std::tuple<QString, int> PerformHTMLSpellCheckReplace(const QString &text,
+//            const QString &search_regex,
+//            const QString &replacement);
 
     static void Accumulate(int &first, const int &second);
 };

--- a/src/Misc/SettingsStore.cpp
+++ b/src/Misc/SettingsStore.cpp
@@ -185,7 +185,7 @@ bool SettingsStore::setLoadMainLanguageDictionary()
     return static_cast<bool>(value(KEY_LOAD_MAIN_LANG_DICT, true).toBool());
 }
 
-bool SettingsStore::setLoadAllLanguagesDIctionaries()
+bool SettingsStore::setLoadAllLanguagesDictionaries()
 {
     clearSettingsGroup();
     return static_cast<bool>(value(KEY_LOAD_ALL_LANG_DICTS, true).toBool());
@@ -419,7 +419,7 @@ void SettingsStore::setLoadMainLanguageDictionary(bool enabled)
     setValue(KEY_LOAD_MAIN_LANG_DICT, enabled);
 }
 
-void SettingsStore::setLoadAllLanguagesDIctionaries(bool enabled)
+void SettingsStore::setLoadAllLanguagesDictionaries(bool enabled)
 {
     clearSettingsGroup();
     setValue(KEY_LOAD_ALL_LANG_DICTS, enabled);

--- a/src/Misc/SettingsStore.h
+++ b/src/Misc/SettingsStore.h
@@ -116,7 +116,7 @@ public:
     bool setLoadLastSessionDictionaries();
     bool setUnloadCurrentDIctionaries();
     bool setLoadMainLanguageDictionary();
-    bool setLoadAllLanguagesDIctionaries();
+    bool setLoadAllLanguagesDictionaries();
 
     int viewState();
 
@@ -287,7 +287,7 @@ public slots:
     void setLoadLastSessionDictionaries(bool enabled);
     void setUnloadCurrentDIctionaries(bool enabled);
     void setLoadMainLanguageDictionary(bool enabled);
-    void setLoadAllLanguagesDIctionaries(bool enabled);
+    void setLoadAllLanguagesDictionaries(bool enabled);
 
     void setViewState(int state);
 

--- a/src/Misc/SpellCheck.h
+++ b/src/Misc/SpellCheck.h
@@ -43,33 +43,26 @@ public:
     static SpellCheck *instance();
     ~SpellCheck();
 
-    struct HunDictionary{
-        Hunspell *hunspell{nullptr};
-        QTextCodec *codec{nullptr};
-        QString wordchars{""};
-    };
+
 
     QStringList userDictionaries();
     QStringList dictionaries();
-    QString currentDictionary() const;
-    bool spell(const QString &word);
-    QStringList suggest(const QString &word);
-    QStringList suggest(const QString &word,const QString languageCode);
+
     QStringList suggestML(const QString &lword);
-    void clearIgnoredWords();
-    void ignoreWord(const QString &word);
-    const bool ignoreWord(const QString &word, const QString &langCode);
-    void ignoreWordInDictionary(const QString &word);
-    const bool ignoreWordInDictionary(const QString &word, const QString &langCode);
 
-    QString getWordChars();
-    const QString getWordChars(const QString lang);
+    void clearMLIgnoredWords(const QString dicName);
+    void clearAllMLIgnoredWords();
 
-    void setDictionary(const QString &name, bool forceReplace = false);
-    void reloadDictionary();
+    const bool ignoreMLWord(const QString lword);
+    const bool ignoreMLWordInDictionary(const QString lword);
 
-    void addToUserDictionary(const QString &word, QString dict_name = "");
-    QStringList allUserDictionaryWords();
+    const QString getMLWordChars(const QString lang);
+
+    void reloadMLDictionary(const QString lang);
+
+    void addToUserDictionary(const QString lword, const QString dictName="");
+
+    QStringList allUserMLDictionaryWords(const QString alias);
     QStringList userDictionaryWords(QString dict_name);
 
 
@@ -78,46 +71,59 @@ public:
      */
     static QString dictionaryDirectory();
     static QString userDictionaryDirectory();
-    static QString currentUserDictionaryFile();
-    static QString userDictionaryFile(QString dict_name);
 
-    void loadDictionaryNames();
 
-    /**
-     * varlog's multilanguage;
-     */
+     bool createUserDictionary(const QString userDictName);
      const QString findDictionary(const QString languageCode);
      void loadDictionaryForLang(const QString languageCode);
-     void unloadDictionary(const QString name);
+     void loadDictionary(const QString dictName);
+     void unloadDictionary(const QString dictName);
+     void reloadAllDictionaries();
      const QStringList alreadyLoadedDics();
+
      void setDCLanguages(const QList<QVariant> dclangs);
-     QString getMainDCLanguage();
+     const QString getMainDCLanguage();
+
      const QString codeToAlias(const QString languageCode);
-     const QStringList aliasToCode(const QString dic);
-     const bool isLoaded(const QString code);
-     void setDictionaryAlias(const QString lang, const QString dic);
+     const QStringList aliasToCode(const QString dictName);
+
+     void setDictionaryAlias(const QString lang, const QString dictName);
      void removeDictionaryAlias(const QString lang);
+
      void WriteSettings();
-     bool spell(const QString word, const QString languageCode);
+
+     bool spellML(const QString word, const QString languageCode);
+
+     const bool isLoaded(const QString code);
+     bool isSpellable(const QString lang);
+
+     const QStringList userDictLaunguages(const QString userDictName);
+
 private:
-     void loadDictionary(const QString dicName);
+
+     struct HunDictionary{
+         Hunspell *hunspell{nullptr};
+         QTextCodec *codec{nullptr};
+         QString wordchars{""};
+     };
+
+     void loadDictionaryNames();
+     const QString currentUserDictionaryFile();
+     const QString userDictionaryFile(const QString dict_name);
+     const bool _ignoreMLWordInDictionary(const QString word, const QString dictName);
+     void _addToUserDictionary(const QString word, const QString dictCode, QString dictName = "");
+     const bool _ignoreMLWord(const QString word, const QString langCode);
+
      void ReadSettings();
      void setUpSpellCheck();
      const QString getCode(const QString dicName);
      void setUpNewBook();
 
-     //end varlog
 
-private:
     SpellCheck();
 
-    Hunspell *m_hunspell;
-    QTextCodec *m_codec;
-    QString m_wordchars;
-    QString m_dictionaryName;
-    //
     QHash<QString, QString> m_dictionaries;
-    QStringList m_ignoredWords;
+    QMap <QString,QStringList> m_ignoredMLWords;
 
     static std::unique_ptr<SpellCheck> m_instance;
 
@@ -125,7 +131,7 @@ private:
     QMap<QString,QString> m_dicAliasTable;
     QStringList m_DCLanguages;
     QString m_mainDCLanguage;
-    QStringList m_lastSessionDics;
+    QStringList m_lastSessionDicts;
 
 };
 

--- a/src/ViewEditors/CodeViewEditor.cpp
+++ b/src/ViewEditors/CodeViewEditor.cpp
@@ -2000,7 +2000,7 @@ void CodeViewEditor::addToDefaultDictionary(const QString &text)
 void CodeViewEditor::ignoreWord(const QString &text)
 {
     SpellCheck *sc = SpellCheck::instance();
-    sc->ignoreWord(text);
+    sc->ignoreMLWord(text);
     emit SpellingHighlightRefreshRequest();
 }
 


### PR DESCRIPTION
Implementing user dictionaries and ignored words turned out to be quite complicated. Obviously both functionalities should be now language aware in a way they weren't before. But what happens to old dictionaries, which the users of Sigil have tended to all those past years?
In order not to break  current usage I decided on following architecture: user dictionary consists of main dictionary "name" and sub-dictionaries "name.dictionary_name" (for instance "default.en_GB" or "default.en"). The main dictionary will be applied to all used dictionaries, sub-dictionary only to appropriate language dictionary. The sub-dictionaries will be automatically created as needed. One of bad consequences of this is that main dictionary name cannot have suffix.
This is probably overkill.
Anyway, I consider the functionality of multilanguage spell check to be on the same level as SIgil's original. I will be still working on it - but mostly I will be waiting for some input. Some independent testing is long overdue. 
  
regards