### PR TITLE
preserve file name

### DIFF
--- a/src/MainUI/MainWindow.cpp
+++ b/src/MainUI/MainWindow.cpp
@@ -797,6 +797,8 @@ bool MainWindow::SaveAs()
 
     // Store the folder the user saved to
     m_LastFolderOpen = QFileInfo(filename).absolutePath();
+    //store new file name
+    m_CurrentFileName=QFileInfo(filename).fileName();
     bool save_result = SaveFile(filename);
 
     if (!save_result) {
@@ -3659,6 +3661,7 @@ void MainWindow::CreateNewBook()
     SetNewBook(new_book);
     new_book->SetModified(false);
     m_SaveACopyFilename = "";
+    m_CurrentFileName.clear();
     UpdateUiWithCurrentFile("");
 }
 
@@ -3710,6 +3713,9 @@ bool MainWindow::LoadFile(const QString &fullfilepath, bool is_internal)
             if (!m_IsInitialLoad) {
                 ShowLastOpenFileWarnings();
             }
+
+            //preserve file name
+            m_CurrentFileName=QFileInfo(fullfilepath).fileName();
 
             if (!is_internal) {
                 // Store the folder the user opened from
@@ -3997,7 +4003,9 @@ const QMap<QString, QString> MainWindow::GetSaveFiltersMap()
 void MainWindow::UpdateUiWithCurrentFile(const QString &fullfilepath)
 {
     m_CurrentFilePath = fullfilepath;
-    m_CurrentFileName = m_CurrentFilePath.isEmpty() ? DEFAULT_FILENAME : QFileInfo(m_CurrentFilePath).fileName();
+    //m_CurrentFileName = m_CurrentFilePath.isEmpty() ? DEFAULT_FILENAME : QFileInfo(m_CurrentFilePath).fileName();
+    if (m_CurrentFilePath.isEmpty() && m_CurrentFileName.isEmpty()) m_CurrentFileName = DEFAULT_FILENAME;
+
     QString epubversion = m_Book->GetConstOPF()->GetEpubVersion();
 
     // Update the titlebar


### PR DESCRIPTION
All programs I use, when converting from one format to another, allow to keep original file name - only changing the suffix. Not so Sigil :(.
This patch brings such an ability to Sigil when using converting plugins like KindleImport - assuming KindleImport allows it by preserving this name  (I'm willing to provide necessary changes to plugin, too) . 
