### PR TITLE
PVS-Studio: An exception should be caught by reference rather than by value.

### DIFF
--- a/src/MainUI/MainWindow.cpp
+++ b/src/MainUI/MainWindow.cpp
@@ -3730,7 +3730,7 @@ bool MainWindow::LoadFile(const QString &fullfilepath, bool is_internal)
         Utility::DisplayStdErrorDialog(
             tr("The creator of this file has encrypted it with DRM. "
                "Sigil cannot open such files."));
-    } catch (EPUBLoadParseError epub_load_error) {
+    } catch (EPUBLoadParseError &epub_load_error) {
         ShowMessageOnStatusBar();
         QApplication::restoreOverrideCursor();
         const QString errors = QString(epub_load_error.what());
@@ -3838,7 +3838,7 @@ bool MainWindow::SaveFile(const QString &fullfilepath, bool update_current_filen
             ShowMessageOnStatusBar(tr("EPUB saved."));
         }
         QApplication::restoreOverrideCursor();
-    } catch (std::runtime_error e) {
+    } catch (std::runtime_error &e) {
         ShowMessageOnStatusBar();
         QApplication::restoreOverrideCursor();
         Utility::DisplayExceptionErrorDialog(tr("Cannot save file %1: %2").arg(fullfilepath).arg(e.what()));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,7 +331,7 @@ int main(int argc, char *argv[])
             widget->show();
             return app.exec();
         }
-    } catch (std::exception e) {
+    } catch (std::exception &e) {
         Utility::DisplayExceptionErrorDialog(e.what());
         return 1;
     }


### PR DESCRIPTION
We have found and fixed a bug using PVS-Studio tool. PVS-Studio is a static code analyzer for C, C++ and C#: https://www.viva64.com/en/pvs-studio/

We suggests having a look at the emails, sent from @pvs-studio.com.

Analyzer warnings: 

- V746 Type slicing. An exception should be caught by reference rather than by value. main.cpp 334
- V746 Type slicing. An exception should be caught by reference rather than by value. MainWindow.cpp 3733
- V746 Type slicing. An exception should be caught by reference rather than by value. MainWindow.cpp 3841