### PR TITLE
Plural forms

### DIFF
--- a/src/Dialogs/ReportsWidgets/AllFilesWidget.cpp
+++ b/src/Dialogs/ReportsWidgets/AllFilesWidget.cpp
@@ -139,7 +139,7 @@ void AllFilesWidget::SetupTable(int sort_column, Qt::SortOrder sort_order)
     rowItems << nitem;
     // Files
     nitem = new NumericItem();
-    nitem->setText(QString::number(m_AllResources.count()) % tr(" files"));
+    nitem->setText(QString(tr("%n file(s)", "", m_AllResources.count())));
     rowItems << nitem;
     // File size
     nitem = new NumericItem();

--- a/src/Dialogs/ReportsWidgets/CSSFilesWidget.cpp
+++ b/src/Dialogs/ReportsWidgets/CSSFilesWidget.cpp
@@ -132,7 +132,7 @@ void CSSFilesWidget::SetupTable(int sort_column, Qt::SortOrder sort_order)
     QList<QStandardItem *> rowItems;
     // Files
     nitem = new NumericItem();
-    nitem->setText(QString::number(m_CSSResources.count()) % tr(" files"));
+    nitem->setText(QString(tr("%n file(s)", "", m_CSSResources.count())));
     rowItems << nitem;
     // File size
     nitem = new NumericItem();

--- a/src/Dialogs/ReportsWidgets/HTMLFilesWidget.cpp
+++ b/src/Dialogs/ReportsWidgets/HTMLFilesWidget.cpp
@@ -180,7 +180,7 @@ void HTMLFilesWidget::SetupTable(int sort_column, Qt::SortOrder sort_order)
     QList<QStandardItem *> rowItems;
     // Files
     nitem = new NumericItem();
-    nitem->setText(QString::number(m_HTMLResources.count()) % tr(" files"));
+    nitem->setText(QString(tr("%n file(s)", "", m_HTMLResources.count()));
     rowItems << nitem;
     // File size
     nitem = new NumericItem();

--- a/src/Dialogs/ReportsWidgets/ImageFilesWidget.cpp
+++ b/src/Dialogs/ReportsWidgets/ImageFilesWidget.cpp
@@ -172,7 +172,7 @@ void ImageFilesWidget::SetupTable(int sort_column, Qt::SortOrder sort_order)
     QList<QStandardItem *> rowItems;
     // Files
     nitem = new NumericItem();
-    nitem->setText(QString::number(m_AllImageResources.count()) % tr(" files"));
+    nitem->setText(QString(tr("%n file(s)", "", m_AllImageResources.count()));
     rowItems << nitem;
     // File size
     nitem = new NumericItem();

--- a/src/MainUI/BookBrowser.cpp
+++ b/src/MainUI/BookBrowser.cpp
@@ -118,13 +118,7 @@ void BookBrowser::RefreshCounts()
     for (int i = 0; i < m_OPFModel->invisibleRootItem()->rowCount(); i++) {
         QStandardItem *folder = m_OPFModel->invisibleRootItem()->child(i);
         int count = folder->rowCount();
-        QString tooltip = QString("%1 ").arg(count);
-
-        if (count == 1) {
-            tooltip.append(tr("file"));
-        } else {
-            tooltip.append(tr("files"));
-        }
+        QString tooltip = QString(tr("%n file(s)","", count));
 
         folder->setToolTip(tooltip);
     }


### PR DESCRIPTION
For better translation quality and because Transifex does not allow translations with a space before the strings.
Sample from German translation:
<pre><code>    &lt;message&gt;
        &lt;location filename=&quot;../../Dialogs/ReportsWidgets/AllFilesWidget.cpp&quot; line=&quot;142&quot;/&gt;
        &lt;source&gt; files&lt;/source&gt;
        &lt;translation&gt;Dateien&lt;/translation&gt;
    &lt;/message&gt;</code>
</pre>