### PR TITLE
Fix utf-8 encode exception if surrogate presented

### DIFF
--- a/src/Resource_Files/python3lib/xmlprocessor.py
+++ b/src/Resource_Files/python3lib/xmlprocessor.py
@@ -67,7 +67,7 @@ def _well_formed(data):
     result = True 
     newdata = data
     if isinstance(newdata, str):
-        newdata = newdata.encode('utf-8')
+        newdata = newdata.encode('utf-8', 'surrogatepass')
     try:
         parser = etree.XMLParser(encoding='utf-8', recover=False)
         tree = etree.parse(BytesIO(newdata), parser)


### PR DESCRIPTION
If surrogate presented in the str, the encode('utf-8') will throw an exception and make sigil crashed. Add the surrogatepass option to allow surrogate.