### PR TITLE
Remove unused variable causing compile warning in GumboInterface.cpp

### DIFF
--- a/src/Misc/GumboInterface.cpp
+++ b/src/Misc/GumboInterface.cpp
@@ -550,7 +550,6 @@ QList<GumboWellFormedError> GumboInterface::error_check()
 QList<GumboWellFormedError> GumboInterface::fragment_error_check()
 {
     QList<GumboWellFormedError> errlist;
-    int line_offset = 0;
 
     // In case we ever have to revert to earlier versions, please note the following
     // additional initialization is needed because Microsoft Visual Studio 2013 (and earlier?)


### PR DESCRIPTION
Gets rid of this warning:

    ~/forks/Sigil/src/Misc/GumboInterface.cpp: In member function ‘QList<GumboWellFormedError> GumboInterface::fragment_error_check()’:
    ~/forks/Sigil/src/Misc/GumboInterface.cpp:553:9: warning: unused variable ‘line_offset’ [-Wunused-variable]
         int line_offset = 0;
             ^
