### PR TITLE
CaseInsensitive sort in Plugins menu

### DIFF
--- a/src/MainUI/MainWindow.cpp
+++ b/src/MainUI/MainWindow.cpp
@@ -307,7 +307,7 @@ void MainWindow::loadPluginsMenu()
     updateToolTipsOnPluginIcons();
 
     QStringList keys = plugins.keys();
-    keys.sort();
+    keys.sort(Qt::CaseInsensitive);
     m_pluginList = keys;
 
     foreach(QString key, keys) {


### PR DESCRIPTION
A small fix when sorting plugin names.