### PR TITLE
Proposal for better support for fonts tooltip

### DIFF
--- a/src/ResourceObjects/FontResource.cpp
+++ b/src/ResourceObjects/FontResource.cpp
@@ -52,7 +52,7 @@ QString FontResource::GetDescription() const
     if (rawfont.weight() <  QFont::ExtraLight)      weight_name = " Thin";
     else if (rawfont.weight() <  QFont::Light)      weight_name = " ExtraLight";
     else if (rawfont.weight() <  QFont::Normal)     weight_name = " Light";
-    else if (rawfont.weight() <  QFont::Medium)     weight_name = "";
+    else if (rawfont.weight() <  QFont::Medium)     weight_name = " Normal";
     else if (rawfont.weight() <  QFont::DemiBold)   weight_name = " Medium";
     else if (rawfont.weight() <  QFont::Bold)       weight_name = " DemiBold";
     else if (rawfont.weight() <  QFont::ExtraBold)  weight_name = " Bold";

--- a/src/ResourceObjects/FontResource.cpp
+++ b/src/ResourceObjects/FontResource.cpp
@@ -48,17 +48,30 @@ QString FontResource::GetDescription() const
     QRawFont rawfont(GetFullPath(), 16.0);
     QString desc = rawfont.familyName();
     QString weight_name;
-    if (rawfont.weight()      <  QFont::ExtraLight) weight_name = "Thin";
-    else if (rawfont.weight() <  QFont::Light)      weight_name = "ExtraLight";
-    else if (rawfont.weight() <  QFont::Normal)     weight_name = "Light";
-    else if (rawfont.weight() <  QFont::Medium)     weight_name = "Normal";
-    else if (rawfont.weight() <  QFont::DemiBold)   weight_name = "Medium";
-    else if (rawfont.weight() <  QFont::Bold)       weight_name = "DemiBold";
-    else if (rawfont.weight() <  QFont::ExtraBold)  weight_name = "Bold";
-    else if (rawfont.weight() <  QFont::Black)      weight_name = "ExtraBold";
-    else if (rawfont.weight() >= QFont::Black)      weight_name = "Black";
-    desc = desc + " " + weight_name;
-    desc = desc + " " + rawfont.styleName();
+    QString style_name;
+    if (rawfont.weight() <  QFont::ExtraLight)      weight_name = " Thin";
+    else if (rawfont.weight() <  QFont::Light)      weight_name = " ExtraLight";
+    else if (rawfont.weight() <  QFont::Normal)     weight_name = " Light";
+    else if (rawfont.weight() <  QFont::Medium)     weight_name = "";
+    else if (rawfont.weight() <  QFont::DemiBold)   weight_name = " Medium";
+    else if (rawfont.weight() <  QFont::Bold)       weight_name = " DemiBold";
+    else if (rawfont.weight() <  QFont::ExtraBold)  weight_name = " Bold";
+    else if (rawfont.weight() <  QFont::Black)      weight_name = " ExtraBold";
+    else if (rawfont.weight() >= QFont::Black)      weight_name = " Black";
+    if (desc != "") {
+        if (desc.contains(weight_name)) weight_name = "";
+        desc = desc + weight_name;
+    }
+
+#ifdef Q_OS_WIN32
+    if (rawfont.style()      == QFont::StyleItalic)  style_name = " Italic";
+    else if (rawfont.style() == QFont::StyleOblique) style_name = " Oblique";
+    else style_name = "";
+#else
+    style_name = " " + rawfont.styleName();
+#endif
+    if (desc != "") desc = desc + style_name;
+    else desc = tr("No reliable font data");
     return desc;
 }
 


### PR DESCRIPTION
rawfont.styleName() is always empty, as a workaround on Windows Italic/Oblique supported by rawfont.style()

For fonts where the family name cannot be read - information about the lack of reliable data (most often for encoded fonts).

"Normal/Regular" is a standard typeface, so this information is redundant.

I tested it on many files with many fonts and it works really well under Windows.
I also added checking that the weight record does not exist in the family name and this has further improved the resulting tooltip.