### PR TITLE
Fix source typos

### DIFF
--- a/src/Dialogs/MetaEditor.cpp
+++ b/src/Dialogs/MetaEditor.cpp
@@ -551,7 +551,7 @@ void MetaEditor::loadMetadataElements()
          tr("Date: Publication") << "dc:date" << tr("The date of publication.") <<
          tr("Date: Creation") << "dcterms:created" << tr("The date of creation.") <<
          tr("Date: Issued") << "dcterms:issued" << tr("The date of modification.") <<
-         tr("Date: Modification") << "dcterms:modfied" << tr("The date of modification.") <<
+         tr("Date: Modification") << "dcterms:modified" << tr("The date of modification.") <<
          tr("Type") << "dc:type" << tr("Used to indicate that the given EPUB Publication is of a specialized type..") <<
          tr("Format") << "dc:format" << tr("The media type or dimensions of the publication. Best practice is to use a value from a controlled vocabulary (e.g. MIME media types).") <<
          tr("Source") << "dc:source" << tr("Identifies the related resource(s) from which this EPUB Publication is derived.") <<
@@ -596,7 +596,7 @@ void MetaEditor::loadMetadataProperties()
     QStringList data;
     data <<
          tr("Id Attribute") << "id" << tr("Optional, typically short, unique identifier string used as an attribute in the Package (opf) document.") <<
-         tr("XML Language") << "xml:lang" << tr("Optional, language specifying attribute.  Uses same codes as dc:language. Not for use with dc:langauge, dc:date, or dc:identifier metadata elements.") <<
+         tr("XML Language") << "xml:lang" << tr("Optional, language specifying attribute.  Uses same codes as dc:language. Not for use with dc:language, dc:date, or dc:identifier metadata elements.") <<
          tr("Text Direction: rtl") << "dir:rtl" << tr("Optional text direction attribute for this metadata item. right-to-left (rtl). Not for use with dc:language, dc:date, or dc:identifier metadata elements.") <<
          tr("Text Direction: ltr") << "dir:ltr" << tr("Optional text direction attribute for this metadata item. left-to-right (ltr). Not for use with dc:language, dc:date, or dc:identifier metadata elements.") <<
          tr("Title Type: main") << "title-type:main" << tr("Indicates the associated title is the main title of the publication.  Only one main title should exist.") <<

--- a/src/Misc/Language.cpp
+++ b/src/Misc/Language.cpp
@@ -157,7 +157,7 @@ void Language::SetLanguageMap()
          "en-IN" << tr("English") + QString(" - ") + tr("India") <<
          "en-IE" << tr("English") + QString(" - ") + tr("Ireland") <<
          "en-JM" << tr("English") + QString(" - ") + tr("Jamaica") <<
-         "en-PH" << tr("English") + QString(" - ") + tr("Phillippines") <<
+         "en-PH" << tr("English") + QString(" - ") + tr("Philippines") <<
          "en-TT" << tr("English") + QString(" - ") + tr("Trinidad") <<
          "en-ZA" << tr("English") + QString(" - ") + tr("South Africa") <<
          "en-US" << tr("English") + QString(" - ") + tr("United States") <<

--- a/src/Misc/SleepFunctions.h
+++ b/src/Misc/SleepFunctions.h
@@ -38,9 +38,9 @@ public:
         QThread::sleep(seconds);
     }
 
-    // Sleep for num "miliseconds"
-    static void msleep(unsigned long miliseconds) {
-        QThread::msleep(miliseconds);
+    // Sleep for num "milliseconds"
+    static void msleep(unsigned long milliseconds) {
+        QThread::msleep(milliseconds);
     }
 
     // Sleep for num "microseconds"


### PR DESCRIPTION
Found via codespell -q 3 -S ./3rdparty,*.ts,*.dic,*.aff -L doubleclick,pres,te,varn