### PR TITLE
Remove border in Preview dock window (undocked)

### DIFF
--- a/src/MainUI/MainWindow.cpp
+++ b/src/MainUI/MainWindow.cpp
@@ -4900,6 +4900,7 @@ void MainWindow::ExtendUI()
 
     m_PreviewWindow = new PreviewWindow(this);
     m_PreviewWindow->setObjectName(PREVIEW_WINDOW_NAME);
+    m_PreviewWindow->setStyleSheet("QDockWidget {border: none;}");
     addDockWidget(Qt::RightDockWidgetArea, m_PreviewWindow);
     // Now that Book View is gone, show Preview by default on new installations
     // tabified with the TOC widget in the RightDockWidgetArea


### PR DESCRIPTION
Only today I noticed that after undocking the preview window there is an ugly frame (only on toolbar).
Especially in dark mode, when the white line "glows in the eyes".

![sigil-preview-window-remove-border](https://user-images.githubusercontent.com/22416021/74051916-2f637700-49d9-11ea-95f7-7d9388409536.png)
