### PR TITLE
Work around dulwich assumption about sys.argv being defined

### DIFF
--- a/src/Resource_Files/python3lib/repomanager.py
+++ b/src/Resource_Files/python3lib/repomanager.py
@@ -34,6 +34,11 @@ import filecmp
 from diffstat import diffstat
 from sdifflibparser import DiffCode, DifflibParser
 
+# Work around dulwich assumption about sys.argv being defined,
+# which is not automatically the case with embedded Python < 3.8.
+if not hasattr(sys, 'argv'):
+    sys.argv  = ['']
+
 import dulwich
 from dulwich import porcelain
 from dulwich.repo import Repo

--- a/src/Resource_Files/python3lib/repomanager.py
+++ b/src/Resource_Files/python3lib/repomanager.py
@@ -35,9 +35,10 @@ from diffstat import diffstat
 from sdifflibparser import DiffCode, DifflibParser
 
 # Work around dulwich assumption about sys.argv being defined,
-# which is not automatically the case with embedded Python < 3.8.
-if not hasattr(sys, 'argv'):
-    sys.argv  = ['']
+# which is not automatically the case on Linux with distribution-provided
+# embedded Python versions older than 3.8.
+if (sys.hexversion < 0x03080000) and not hasattr(sys, 'argv'):
+    sys.argv = ['']
 
 import dulwich
 from dulwich import porcelain


### PR DESCRIPTION
dulwich.server's main() assumes sys.argv is always defined, however
that's not the case with embedded Python older than 3.8, as discussed
in https://bugs.python.org/issue32573

We can work around that by defining a fallback sys.argv initialized
with an empty list if sys.argv isn't defined before importing any
dulwich modules.

The relevant traceback looks like this:

Traceback (most recent call last):
    File "/usr/share/sigil/python3lib/repomanager.py", line 38, in <module>
        from dulwich import porcelain
    File "/usr/lib/python3/dist-packages/dulwich/porcelain.py", line 121, in <module>
        from dulwich.server import (
    File "/usr/lib/python3/dist-packages/dulwich/server.py", line 1069, in <module>
        def main(argv=sys.argv):
    AttributeError: module 'sys' has no attribute 'argv'