### PR TITLE
Fix epub3 mapping functions in bookcontainer and outputcontainer

### DIFF
--- a/src/Resource_Files/plugin_launchers/python/bookcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/bookcontainer.py
@@ -368,13 +368,13 @@ class BookContainer(object):
 
     # New for epub3
     def id_to_properties(self, id, ow=None):
-        return self._w.map_id_to_props.get(id, ow)
+        return self._w.map_id_to_properties(id, ow)
 
     def id_to_fallback(self, id, ow=None):
-        return self._w.map_id_to_fall.get(id, ow)
+        return self._w.map_id_to_fallback(id, ow)
 
     def id_to_overlay(self, id, ow=None):
-        return self._w.map_id_to_over.get(id, ow)
+        return self._w.map_id_to_overlay(id, ow)
 
 
     # New in Sigil 1.1

--- a/src/Resource_Files/plugin_launchers/python/outputcontainer.py
+++ b/src/Resource_Files/plugin_launchers/python/outputcontainer.py
@@ -293,13 +293,13 @@ class OutputContainer(object):
 
     # New for epub3
     def id_to_properties(self, id, ow=None):
-        return self._w.map_id_to_props.get(id, ow)
+        return self._w.map_id_to_properties(id, ow)
 
     def id_to_fallback(self, id, ow=None):
-        return self._w.map_id_to_fall.get(id, ow)
+        return self._w.map_id_to_fallback(id, ow)
 
     def id_to_overlay(self, id, ow=None):
-        return self._w.map_id_to_over.get(id, ow)
+        return self._w.map_id_to_overlay(id, ow)
 
 
     # New in Sigil 1.1


### PR DESCRIPTION
Hi Kevin, Doug,
I stumbled upon an error on the epub3 mapping routines in bookcontainer.py and outputcontainer.py. It seems that they remained halfway between invoking the id_to_* dictionaries and the map_id_to_* methods of the wrapper object. I think this commit should fix that.
Thanks!