### PR TITLE
Checkbox in Delete Unused Stylesheet Selectors to select/unselect all

### DIFF
--- a/src/Dialogs/DeleteStyles.cpp
+++ b/src/Dialogs/DeleteStyles.cpp
@@ -127,6 +127,8 @@ void DeleteStyles::ReadSettings()
         restoreGeometry(geometry);
     }
 
+    ui.ToggleSelectAll->setCheckState(Qt::Checked);
+
     settings.endGroup();
 }
 
@@ -147,8 +149,18 @@ void DeleteStyles::DoubleClick(const QModelIndex index)
     emit OpenFileRequest(filename, -1, position);
 }
 
+void DeleteStyles::SelectUnselectAll(bool value)
+{
+    Qt::CheckState checkboxValue = (value ? Qt::Checked : Qt::Unchecked);
+    for (int row = 0; row < m_Model.rowCount(); row++) {
+        QStandardItem *checkbox = m_Model.itemFromIndex(m_Model.index(row, 0));
+        checkbox->setCheckState(checkboxValue);
+    }
+}
+
 void DeleteStyles::ConnectSignals()
 {
     connect(this, SIGNAL(accepted()), this, SLOT(SaveStylesToDelete()));
     connect(ui.Table, SIGNAL(doubleClicked(const QModelIndex &)), this, SLOT(DoubleClick(const QModelIndex &)));
+    connect(ui.ToggleSelectAll, SIGNAL(clicked(bool)), this, SLOT(SelectUnselectAll(bool)));
 }

--- a/src/Dialogs/DeleteStyles.h
+++ b/src/Dialogs/DeleteStyles.h
@@ -53,6 +53,7 @@ private slots:
     void SaveStylesToDelete();
     void WriteSettings();
     void DoubleClick(const QModelIndex index);
+    void SelectUnselectAll(bool value);
 
 private:
     void SetUpTable();

--- a/src/Form_Files/DeleteStyles.ui
+++ b/src/Form_Files/DeleteStyles.ui
@@ -22,6 +22,13 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="ToggleSelectAll">
+     <property name="text">
+      <string>Select / Unselect all</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>


### PR DESCRIPTION
I've added a checkbox in _Delete Unused Stylesheet Selectors_ to toggle the selection of all items.

It works, I've tried to follow name conventions used in the code.

But never used QT, so I've edited the .ui file by hand. Also, haven't done anything about the label for the checkbox and i18n. Don't know where to modify that.
