### PR TITLE
Replace documentation references to the older PCRE lib with refs to PCRE2

### DIFF
--- a/docs/Building_on_Linux.html
+++ b/docs/Building_on_Linux.html
@@ -53,11 +53,11 @@ To get Sigil's Qt5 requirements, <code>sudo apt-get install</code> the following
 <p>Sigil will provide the extra third-party libs if you do nothing, but most (if not all) of Sigil's third-party dependencies should be avialable in your software repos. If you want to make use of them, <code>sudo apt-get install</code> the following packages.</p>
 <ul>
 <li>libhunspell-dev</li>
-<li>libpcre3-dev</li>
+<li>libpcre2-dev</li>
 <li>libminizip-dev</li>
 </ul>
 <p>The folllowing command can be copied and pasted for convenience:</p>
-<p><code>sudo apt-get install libhunspell-dev libpcre3-dev libminizip-dev</code></p>
+<p><code>sudo apt-get install libhunspell-dev libpcre2-dev libminizip-dev</code></p>
 <p>If you do install them, remember to use use the -DUSE_SYSTEM_LIBS=1 option when configuring Sigil with cmake later on. Otherwise, the build process will ignore them and provide/build its own.</p>
 <h2><a name="python"/>Getting Python 3.4 (or higher)</h2>
 <p>On Ubuntu/Debian <code>sudo apt-get install</code> (at a minimum) the following packages:</p>

--- a/docs/Building_on_Linux.md
+++ b/docs/Building_on_Linux.md
@@ -53,12 +53,12 @@ The folllowing command can be copied and pasted for convenience:
 Sigil will provide the extra third-party libs if you do nothing, but most (if not all) of Sigil's third-party dependencies should be avialable in your software repos. If you want to make use of them, `sudo apt-get install` the following packages.
 
 + libhunspell-dev
-+ libpcre3-dev
++ libpcre2-dev
 + libminizip-dev
 
 The folllowing command can be copied and pasted for convenience:
 
-`sudo apt-get install libhunspell-dev libpcre3-dev libminizip-dev`
+`sudo apt-get install libhunspell-dev libpcre2-dev libminizip-dev`
 
 If you do install them, remember to use use the -DUSE_SYSTEM_LIBS=1 option when configuring Sigil with cmake later on. Otherwise, the build process will ignore them and provide/build its own.
 


### PR DESCRIPTION
Replace references to the older PCRE lib with refs to PCRE2 in the Linux build documentation.

It should be noted that

* Ubuntu 18.04 LTS ships pcre2 10.31
* Ubuntu 20.04 LTS ships pcre2 10.34
* Ubuntu 21.01 ships pcre2 10.36, however since it's going EOL in January 2022 it's not really relevant any longer
* Ubuntu 21.10 ships pcre2 10.37 (goes EOL in July 2022)
* Ubuntu 22.04 LTS (not yet released) is the only one which currently ships pcre2 10.39