### PR TITLE
Correct QComboBox Class signals

### DIFF
--- a/src/Dialogs/HeadingSelector.cpp
+++ b/src/Dialogs/HeadingSelector.cpp
@@ -1024,10 +1024,17 @@ void HeadingSelector::ConnectSignalsToSlots()
     connect(this,               SIGNAL(accepted()),
             this,               SLOT(UpdateHeadingElements())
            );
+    #if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     connect(ui.cbTOCSetHeadingLevel,
             SIGNAL(activated(const QString &)),
             this,               SLOT(SelectHeadingLevelInclusion(const QString &))
            );
+    #else
+    connect(ui.cbTOCSetHeadingLevel,
+            SIGNAL(textActivated(const QString &)),
+            this,               SLOT(SelectHeadingLevelInclusion(const QString &))
+           );
+    #endif
     connect(ui.left,             SIGNAL(clicked()), this, SLOT(DecreaseHeadingLevel()));
     connect(ui.right,            SIGNAL(clicked()), this, SLOT(IncreaseHeadingLevel()));
     connect(ui.rename,           SIGNAL(clicked()), this, SLOT(Rename()));


### PR DESCRIPTION
There are two signals:
activated(int index) and textActivated(const QString &text),
the code made bad use of it.
See https://doc.qt.io/qt-5/qcombobox.html#signals or
https://doc-snapshots.qt.io/qt6-dev/qcombobox.html#signals .

It has caused me bug in my Qt6 build, I was not able to use the include toc function.