### PR TITLE
docs(readme): update winget hyperlink

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ For Installing/Building on Windows
 
 Sigil currently provides Windows installers for x86 and x64 and will only work on Windows 8 or newer. There's a Legacy installer that's suitable for Windows 7.
 
-The latest Sigil versions are also typically available via the [winget (Windows 10+)](https://winget.run/pkg/Sigil-Ebook/Sigil), [Chocolatey (Windows 7+)](https://community.chocolatey.org/packages/Sigil), and [Npackd](https://npackd.appspot.com/p?q=sigil) Windows package managers. There are no "scary" Microsoft warnings about unknown publishers if you install Sigil via one of these package managers. 
+The latest Sigil versions are also typically available via the [winget (Windows 10+)](https://winstall.app/apps/Sigil-Ebook.Sigil), [Chocolatey (Windows 7+)](https://community.chocolatey.org/packages/Sigil), and [Npackd](https://npackd.appspot.com/p?q=sigil) Windows package managers. There are no "scary" Microsoft warnings about unknown publishers if you install Sigil via one of these package managers. 
 
 To build Sigil on Windows yourself, see:
 


### PR DESCRIPTION
https://winget.run does not get updated with the winget-pkgs repository and displays older version. hence, switching to https://winstall.app which is updated in (almost) realtime, and provides a better UI/UX too ;)