### PR TITLE
Typo

### DIFF
--- a/src/MainUI/PreviewWindow.cpp
+++ b/src/MainUI/PreviewWindow.cpp
@@ -252,7 +252,7 @@ void PreviewWindow::SetupView()
     m_reloadAction->setToolTip(tr("Update Preview Window"));
 
     m_cycleCSSAction = new QAction(QIcon(":/main/cycle-css.svg"),"", this);
-    m_reloadAction ->setEnabled(false);
+    m_cycleCSSAction ->setEnabled(false);
     m_cycleCSSAction->setToolTip(tr("Cycle Custom CSS Files"));
     
     QToolBar * tb = new QToolBar();


### PR DESCRIPTION
Reload page was grayed accidentally.

Disable for icons works:

![disable_works](https://user-images.githubusercontent.com/22416021/177374527-900b159d-964e-4726-9467-a2cb85307a3c.png)
