### PR TITLE
Catch AttributeError in addition to OSError in pluginhunspell.py

### DIFF
--- a/src/Resource_Files/plugin_launchers/python/pluginhunspell.py
+++ b/src/Resource_Files/plugin_launchers/python/pluginhunspell.py
@@ -47,7 +47,7 @@ class HunspellChecker(object):
         try:
             # First use bundled hunspell location.
             self.hunspell = cdll[hunspell_dllpath]
-        except OSError:
+        except (OSError, AttributeError):
             # No bundled (or incompatible bundled) libhunspell found.
             # found. So search for system libhunspell.
             self.hunspell = None


### PR DESCRIPTION
Catch AttributeError in addition to OSError in pluginhunspell.py to work around Python 3.12.0a4 ctypes.cdll behavior change introduced in [this commit](https://github.com/python/cpython/commit/101cfe679fe10b9b662e815999dadf81fcc32c9c) as a response to [this issue](https://github.com/python/cpython/issues/78997): In 3.12.0a4 or newer, a key lookup when treating `cdll` as a dict no longer raises an `OSError`, but instead raises an `AttributeError`.

Fixes #741 .

This change is backwards compatible with any Python version.

Alternatively, instead of `cdll[hunspell_dllpath]` we could use `cdll.LoadLibrary(hunspell_dllpath)` there, but:

* I'm not too sure of the implications for older Python versions and for Windows, since having fspath-like objects work there is a recent ctypes addition
* I suspect that may introduce trouble on Windows -- for Linux we'd need the full path to the .so, while on Windows we must not use that

so let's be cautious and just catch the new exception, since this way we won't need to rely on any dynloader implementation subtleties.