### PR TITLE
Ensure re uses raw strings under Python 3.12, part deux

### DIFF
--- a/src/Resource_Files/plugin_launchers/python/sigil_bs4/dammit.py
+++ b/src/Resource_Files/plugin_launchers/python/sigil_bs4/dammit.py
@@ -47,9 +47,9 @@ except ImportError:
     pass
 
 xml_encoding_re = re.compile(
-    r'^<\?.*encoding=[\'"](.*?)[\'"].*\?>'.encode(), re.I)
+    r'''^<\?.*encoding=['"](.*?)['"].*\?>'''.encode(), re.I)
 html_meta_re = re.compile(
-    r'<\s*meta[^>]+charset\s*=\s*["\']?([^>]*?)[ /;\'">]'.encode(), re.I)
+    r'''<\s*meta[^>]+charset\s*=\s*["']?([^>]*?)[ /;'">]'''.encode(), re.I)
 
 class EntitySubstitution(object):
 
@@ -83,7 +83,9 @@ class EntitySubstitution(object):
         "\u00a0" : "#160",
         }
 
-    BARE_AMPERSAND_OR_BRACKET = re.compile(r"([<>\u00a0]|&(?!#\d+;|#x[0-9a-fA-F]+;|\w+;))")
+    BARE_AMPERSAND_OR_BRACKET = re.compile(r"([<>\u00a0]|"
+                                           r"&(?!#\d+;|#x[0-9a-fA-F]+;|\w+;)"
+                                           ")")
 
     IS_ENTITY = re.compile(r"(&#\d+;|&#x[0-9a-fA-F]+;|&\w+;)")
 


### PR DESCRIPTION
Commit 434a407 solves the SyntaxWarnings in sigil_bs4/element.py. Let's do the same for dammit.py as well.
These were trickier due to the single quotes; solved using triple-quoted strings.
Have checked that this doesn't change the runtime values of the resulting strings under Python versions 2.9, 3.9, 3.11, and of course 3.12.

Aside: Accidentally double-checked that the fixes in 434a407 didn't change the resulting values for element.py as well: Initially I was working off 2.1.0-release by mistake, fixed the issue in both files, and only found out about the existence of 434a407 when I noticed that git wasn't detecting any changes in element.py :)

This fixes:

    /usr/share/sigil/plugin_launchers/python/sigil_bs4/dammit.py:50: SyntaxWarning: invalid escape sequence '\?'
      '^<\?.*encoding=[\'"](.*?)[\'"].*\?>'.encode(), re.I)
    /usr/share/sigil/plugin_launchers/python/sigil_bs4/dammit.py:52: SyntaxWarning: invalid escape sequence '\s'
      '<\s*meta[^>]+charset\s*=\s*["\']?([^>]*?)[ /;\'">]'.encode(), re.I)
    /usr/share/sigil/plugin_launchers/python/sigil_bs4/dammit.py:87: SyntaxWarning: invalid escape sequence '\d'
      "&(?!#\d+;|#x[0-9a-fA-F]+;|\w+;)"
    /usr/share/sigil/plugin_launchers/python/sigil_bs4/dammit.py:90: SyntaxWarning: invalid escape sequence '\d'
      IS_ENTITY = re.compile("(&#\d+;|&#x[0-9a-fA-F]+;|&\w+;)")

Please note that I have *NOT* touched sigil_custom_changes_to_bs4-4.4.0.patch.txt since I'm not 100% on whether that's still up to date, how it was generated, and so on. Depending on our policy on how to handle that file it might be necessary to regenerate it to include the changes.