### PR TITLE
New Lines in Messages

### DIFF
--- a/src/Dialogs/PreferenceWidgets/GeneralSettingsWidget.cpp
+++ b/src/Dialogs/PreferenceWidgets/GeneralSettingsWidget.cpp
@@ -208,7 +208,9 @@ void GeneralSettingsWidget::setXEditorPath()
                                                        NAME_FILTER,
                                                        0,
                                                        options);
-    ui.lineEdit7->setText(xeditorPath);
+    if (!xeditorPath.isEmpty()) {
+        ui.lineEdit7->setText(xeditorPath);
+    }
 }
 
 void GeneralSettingsWidget::XEditorPathChanged()

--- a/src/Dialogs/PreferenceWidgets/GeneralSettingsWidget.cpp
+++ b/src/Dialogs/PreferenceWidgets/GeneralSettingsWidget.cpp
@@ -208,9 +208,7 @@ void GeneralSettingsWidget::setXEditorPath()
                                                        NAME_FILTER,
                                                        0,
                                                        options);
-    if (!xeditorPath.isEmpty()) {
-        ui.lineEdit7->setText(xeditorPath);
-    }
+    ui.lineEdit7->setText(xeditorPath);
 }
 
 void GeneralSettingsWidget::XEditorPathChanged()

--- a/src/Importers/ImportEPUB.cpp
+++ b/src/Importers/ImportEPUB.cpp
@@ -253,8 +253,8 @@ QSharedPointer<Book> ImportEPUB::GetBook(bool extract_metadata)
         if (extract_metadata) {
             m_Book->GetOPF()->SetDCMetadata(originalMetadata);
         }
-        AddLoadWarning(QObject::tr("The OPF file does not contain a valid spine.") % "\n" %
-                       QObject::tr("Sigil has created a new one for you.") % "\n" %
+        AddLoadWarning(QObject::tr("The OPF file does not contain a valid spine.") % "<br>" %
+                       QObject::tr("Sigil has created a new one for you.") % "<br>" %
                        QObject::tr("Please verify and correct the OPF Spine order."));
     }
 
@@ -936,8 +936,8 @@ void ImportEPUB::LocateOrCreateNCX(const QString &ncx_id_on_spine)
             resource->SetSavedDate(std::get<2>(ainfo));
 	    }
         m_NCXNotInManifest = false;
-        load_warning = QObject::tr("The OPF file did not identify the NCX file correctly.") + "\n" + 
-                               " - "  +  QObject::tr("Sigil has used the following file as the NCX:") + 
+        load_warning = QObject::tr("The OPF file did not identify the NCX file correctly.") + "<br>" + 
+                               QObject::tr("Sigil has used the following file as the NCX:") + 
                                QString(" %1").arg(m_NcxCandidates[ m_NCXId ]);
 
         AddLoadWarning(load_warning);
@@ -960,8 +960,8 @@ void ImportEPUB::LocateOrCreateNCX(const QString &ncx_id_on_spine)
 
     m_NCXNotInManifest = true;
 
-    load_warning = QObject::tr("The OPF file does not contain an NCX file.") + "\n" + 
-                               " - " +  QObject::tr("Sigil has created a new one for you.");
+    load_warning = QObject::tr("The OPF file does not contain an NCX file.") + "<br>" + 
+                               QObject::tr("Sigil has created a new one for you.");
 
     m_NCXFilePath = QFileInfo(m_OPFFilePath).absolutePath() + "/toc.ncx";
 

--- a/src/Importers/ImportEPUB.cpp
+++ b/src/Importers/ImportEPUB.cpp
@@ -878,24 +878,26 @@ void ImportEPUB::LocateOrCreateNCX(const QString &ncx_id_on_spine)
 
     // handle the normal/proper case of an ncx id on the spine matching an ncx candidate that exists
     if (!m_NCXId.isEmpty() && m_NcxCandidates.contains(m_NCXId)) {
-        QString bookpath;
         ncx_href = m_NcxCandidates[ m_NCXId ];
         m_NCXFilePath = QFileInfo(m_OPFFilePath).absolutePath() % "/" % ncx_href;
         m_NCXFilePath = Utility::resolveRelativeSegmentsInFilePath(m_NCXFilePath, "/");
-        bookpath = m_NCXFilePath.right(m_NCXFilePath.length() - m_ExtractedFolderPath.length() - 1);
-        QString ncx_text = CleanSource::ProcessXML(Utility::ReadUnicodeTextFile(m_NCXFilePath),
-                                                   "application/x-dtbncx+xml");
-        NCXResource* resource = m_Book->GetFolderKeeper()->AddNCXToFolder(m_PackageVersion, bookpath);
-        resource->SetText(ncx_text);
-        resource->SaveToDisk(false);
-        if (m_FileInfoFromZip.contains(bookpath)) {
-            std::tuple<size_t, QString, QString> ainfo = m_FileInfoFromZip[bookpath];
-            resource->SetSavedSize(std::get<0>(ainfo));
-            resource->SetSavedCRC32(std::get<1>(ainfo));
-            resource->SetSavedDate(std::get<2>(ainfo));
-	    }
-        m_NCXNotInManifest = false;
-        return;
+        if (QFile::exists(m_NCXFilePath)) {
+            QString ncx_text = Utility::ReadUnicodeTextFile(m_NCXFilePath);
+            ncx_text = CleanSource::ProcessXML(ncx_text, "application/x-dtbncx+xml");
+            QString bookpath = m_NCXFilePath.right(m_NCXFilePath.length() - m_ExtractedFolderPath.length() - 1);
+            NCXResource* resource = m_Book->GetFolderKeeper()->AddNCXToFolder(m_PackageVersion, bookpath);
+            resource->SetText(ncx_text);
+            resource->SaveToDisk(false);
+            if (m_FileInfoFromZip.contains(bookpath)) {
+                std::tuple<size_t, QString, QString> ainfo = m_FileInfoFromZip[bookpath];
+                resource->SetSavedSize(std::get<0>(ainfo));
+                resource->SetSavedCRC32(std::get<1>(ainfo));
+                resource->SetSavedDate(std::get<2>(ainfo));
+	        }
+            m_NCXNotInManifest = false;
+            return;
+        }
+        // No NCX file exists at the path specified in the manifest and pointed to by spine toc
     }
 
     bool found = false;
@@ -923,25 +925,29 @@ void ImportEPUB::LocateOrCreateNCX(const QString &ncx_id_on_spine)
         ncx_href = m_NcxCandidates[ m_NCXId ];
         m_NCXFilePath = QFileInfo(m_OPFFilePath).absolutePath() % "/" % ncx_href;
         m_NCXFilePath = Utility::resolveRelativeSegmentsInFilePath(m_NCXFilePath, "/");
-        QString ncx_text = CleanSource::ProcessXML(Utility::ReadUnicodeTextFile(m_NCXFilePath),
-                                                   "application/x-dtbncx+xml");
-        QString bookpath = m_NCXFilePath.right(m_NCXFilePath.length() - m_ExtractedFolderPath.length() - 1);
-        NCXResource* resource = m_Book->GetFolderKeeper()->AddNCXToFolder(m_PackageVersion, bookpath);
-        resource->SetText(ncx_text);
-        resource->SaveToDisk(false);
-        if (m_FileInfoFromZip.contains(bookpath)) {
-            std::tuple<size_t, QString, QString> ainfo = m_FileInfoFromZip[bookpath];
-            resource->SetSavedSize(std::get<0>(ainfo));
-            resource->SetSavedCRC32(std::get<1>(ainfo));
-            resource->SetSavedDate(std::get<2>(ainfo));
-	    }
-        m_NCXNotInManifest = false;
-        load_warning = QObject::tr("The OPF file did not identify the NCX file correctly.") + "<br>" + 
+        if (QFile::exists(m_NCXFilePath)) {
+            QString ncx_text = CleanSource::ProcessXML(Utility::ReadUnicodeTextFile(m_NCXFilePath),
+                                                       "application/x-dtbncx+xml");
+            QString bookpath = m_NCXFilePath.right(m_NCXFilePath.length() - m_ExtractedFolderPath.length() - 1);
+            NCXResource* resource = m_Book->GetFolderKeeper()->AddNCXToFolder(m_PackageVersion, bookpath);
+            resource->SetText(ncx_text);
+            resource->SaveToDisk(false);
+            if (m_FileInfoFromZip.contains(bookpath)) {
+                std::tuple<size_t, QString, QString> ainfo = m_FileInfoFromZip[bookpath];
+                resource->SetSavedSize(std::get<0>(ainfo));
+                resource->SetSavedCRC32(std::get<1>(ainfo));
+                resource->SetSavedDate(std::get<2>(ainfo));
+	        }
+            m_NCXNotInManifest = false;
+            load_warning = QObject::tr("The OPF file did not identify the NCX file correctly.") + "<br>" + 
                                QObject::tr("Sigil has used the following file as the NCX:") + 
                                QString(" %1").arg(m_NcxCandidates[ m_NCXId ]);
 
-        AddLoadWarning(load_warning);
-        return;
+            AddLoadWarning(load_warning);
+            return;
+        }
+        // again file with ncx extension in manifest is missing
+        found = false;
     }
 
     // An NCX is only required in epub2 so punt here if epub3


### PR DESCRIPTION
Since the `\n` character did not create a new line in the messages, I added `<br>` in three places. This works well.
Below is the before and after view.

Message One:
![sigil-no-valid-spine-before](https://github.com/user-attachments/assets/1aa2ffc1-c1a2-4b35-965c-fb2a5724622c)
![sigil-no-valid-spine-after](https://github.com/user-attachments/assets/23c2fb54-458e-416e-9ca0-22e96a81fad8)


Message Two:
![sigil-no-identify-ncx-before](https://github.com/user-attachments/assets/9ed817f6-90da-490c-93a2-3c6178679ecd)
![sigil-no-identify-ncx-after](https://github.com/user-attachments/assets/12891fd8-0e13-471d-9faa-00ff612c88da)


Message Three:
![sigil-no-ncx-before](https://github.com/user-attachments/assets/df383879-6683-4a7f-8eee-01ade441310a)
![sigil-no-ncx-after](https://github.com/user-attachments/assets/8fa72599-71bd-4f27-9d73-efac378ffc66)

