### PR TITLE
Make sanitycheck.py (WellFormedCheckEpub) look for both missing quotes

### DIFF
--- a/src/Resource_Files/python3lib/sanitycheck.py
+++ b/src/Resource_Files/python3lib/sanitycheck.py
@@ -160,7 +160,7 @@ class SanityCheck(object):
                     while s[p:p+1] != qt: 
                         p += 1
                         # Opening quote with no closing quote
-                        if p >= taglen:  # Don't cross the next '=' boundary when seeking matching quote
+                        if p >= taglen:
                             error_msg = 'Attribute "' +  aname +  '" has unmatched quotes on attribute value'
                             self.errors.append((self.tag_start[0], self.tag_start[1], error_msg))
                             self.has_error = True

--- a/src/Resource_Files/python3lib/sanitycheck.py
+++ b/src/Resource_Files/python3lib/sanitycheck.py
@@ -159,7 +159,8 @@ class SanityCheck(object):
                     b = p
                     while s[p:p+1] != qt: 
                         p += 1
-                        if p >= taglen:
+                        # Opening quote with no closing quote
+                        if s[p:p+1] == '=' or p >= taglen:  # Don't cross the next '=' boundary when seeking matching quote
                             error_msg = 'Attribute "' +  aname +  '" has unmatched quotes on attribute value'
                             self.errors.append((self.tag_start[0], self.tag_start[1], error_msg))
                             self.has_error = True
@@ -170,6 +171,12 @@ class SanityCheck(object):
                     b = p
                     while s[p:p+1] not in ('>', '/', ' ') : 
                         p += 1
+                        # Closing quote with no opening quote
+                        if s[p:p+1] in ('"', "'"):
+                            error_msg = 'Attribute "' +  aname +  '" has unmatched quotes on attribute value'
+                            self.errors.append((self.tag_start[0], self.tag_start[1], error_msg))
+                            self.has_error = True
+                            return None, None, None
                         if p >= taglen:
                             error_msg = 'Attribute "' + aname + '" has unterminated attribute value' 
                             self.errors.append((self.tag_start[0], self.tag_start[1], error_msg))

--- a/src/Resource_Files/python3lib/sanitycheck.py
+++ b/src/Resource_Files/python3lib/sanitycheck.py
@@ -160,7 +160,7 @@ class SanityCheck(object):
                     while s[p:p+1] != qt: 
                         p += 1
                         # Opening quote with no closing quote
-                        if s[p:p+1] == '=' or p >= taglen:  # Don't cross the next '=' boundary when seeking matching quote
+                        if p >= taglen:  # Don't cross the next '=' boundary when seeking matching quote
                             error_msg = 'Attribute "' +  aname +  '" has unmatched quotes on attribute value'
                             self.errors.append((self.tag_start[0], self.tag_start[1], error_msg))
                             self.has_error = True


### PR DESCRIPTION
Any reason why sanitycheck.py shouldn't (or  can't) look for both missing opening AND closing attribute quotes like xmlsanitycheck.py does?

https://www.mobileread.com/forums/showthread.php?p=4456608#post4456608