### PR TITLE
Update tooltip for tabs after rename

### DIFF
--- a/src/Tabs/TabManager.cpp
+++ b/src/Tabs/TabManager.cpp
@@ -509,6 +509,7 @@ void TabManager::UpdateTabName(ContentTab *renamed_tab)
 {
     Q_ASSERT(renamed_tab);
     setTabText(indexOf(renamed_tab), renamed_tab->GetShortPathName());
+    setTabToolTip(indexOf(renamed_tab), renamed_tab->GetShortPathName());
 }
 
 void TabManager::SetFocusInTab()


### PR DESCRIPTION
This detail has always annoyed me, so I finally corrected it.
![sigil-tab-update-tooltip](https://github.com/user-attachments/assets/7a89cbf2-cb7a-4f0e-ad32-bb1e9b88798c)
