### PR TITLE
Fix various typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Linux Build and Install
 
 Starting with Sigil 2.3.0, Qt6.4 is the minimum requirement to build Sigil. You'll need to use an older version if you need to build with Qt5.
 
-For newer Linux systems like Ubuntu 23.04 (and its derivitives), or Arch Linux, or Debian Trixie or Unstable, you should be able to compile Sigil using repo-provided dependencies. Instructions for doing so can be found in:
+For newer Linux systems like Ubuntu 23.04 (and its derivatives), or Arch Linux, or Debian Trixie or Unstable, you should be able to compile Sigil using repo-provided dependencies. Instructions for doing so can be found in:
 
 > [docs/Building_on_Linux.md](./docs/Building_on_Linux.md)
 
@@ -112,7 +112,7 @@ Currently these projects include:
 * jQuery.ScrollTo-2.1.2 (src/Resource_Files/javascript/jquery.scrollTo-2.1.2.min.js)
 * MathJax.js Version 3.2.X [required minimum is 3.2.2]: (src/Resource_Files/polyfills)
 
-In addtion, Sigil uses the following other packages that have been specifically
+In addition, Sigil uses the following other packages that have been specifically
 modified for use inside Sigil:
 
 * Beautiful Soup 4 (src/Resource_Files/plugin_launchers/sigil_bs4)

--- a/docs/Building_PySide6_for_Qt6_on_MacOSX.txt
+++ b/docs/Building_PySide6_for_Qt6_on_MacOSX.txt
@@ -26,7 +26,7 @@ which python3
 # Prerequisites
 
 # Your may need to have the packaging module installed on your python3
-# and instll setuptools module
+# and install setuptools module
 # pip3 install --upgrade packaging
 # pip3 install --upgrade setuptools
 

--- a/docs/Building_on_Linux.md
+++ b/docs/Building_on_Linux.md
@@ -80,7 +80,7 @@ The following command can be copied and pasted for convenience on Debian-based s
 **Note:** On Debian-based systems, you may need to also install the libgl1-mesa-dev package if cmake complains of missing OpenGL headers and/or includes
 
 ## <a name="thirdparty"/>3rd-Party Dependencies (optional step)
-Sigil will provide the extra third-party libs if you do nothing, but most (if not all) of Sigil's third-party dependencies should be avialable in your software repos. If you want to make use of them on Arch, `sudo pacman -S` the following packages.
+Sigil will provide the extra third-party libs if you do nothing, but most (if not all) of Sigil's third-party dependencies should be available in your software repos. If you want to make use of them on Arch, `sudo pacman -S` the following packages.
 
 + hunspell
 + pcre2
@@ -260,7 +260,7 @@ There are several configuration and environment variable options that can tailor
 
 -DMATHJAX_DIR=`<path>` **Only for Sigil 1.9.10 and earlier!** If you would like use your system's MathJax implementation instead of the one that comes bundled with Sigil, use this cmake directive when first configuring. A minimum of MathJax v2.7.0 is required to work with Sigil. NOTE: if -DMATHJAX_DIR=`<path>` is used, Sigil will install a config script to `<path>`/config/local. This file is required for Sigil's Preview to be able properly render MathML. This feature was added between Sigil 0.9.12 and 0.9.13.
 
--DMATHJAX3_DIR=`<path>` **Only for Sigil 1.9.20 and Later!** If you would like use your system's MathJax implementation instead of the one that comes bundled with Sigil, use this cmake directive when first configuring. A minimum of MathJax v3.2.2 is required to work with Sigil. MathJax 3.2.2+ is required for Sigil's Preview to be able properly render MathML starting with Sigil v1.9.20. Ensure your system MathJax meets this minimum version requirement before using usinf this CMAKE define.
+-DMATHJAX3_DIR=`<path>` **Only for Sigil 1.9.20 and Later!** If you would like use your system's MathJax implementation instead of the one that comes bundled with Sigil, use this cmake directive when first configuring. A minimum of MathJax v3.2.2 is required to work with Sigil. MathJax 3.2.2+ is required for Sigil's Preview to be able properly render MathML starting with Sigil v1.9.20. Ensure your system MathJax meets this minimum version requirement before using this CMAKE define.
 
 -DINSTALL_HICOLOR_ICONS=(0|1) Install various-sized Sigil application icons to the typical hicolor theme directories (`<INSTALL_PREFIX>/share/icons/hicolor`). The default is 0, which installs a single icon to the `<INSTALL_PREFIX>/share/pixmap` folder.
 

--- a/docs/Building_on_Linux_older.md
+++ b/docs/Building_on_Linux_older.md
@@ -49,18 +49,18 @@ To get Sigil's Qt5 requirements, `sudo apt-get install` the following packages:
 + libqt5svg5-dev (build requirement starting with Sigil v2.1.0)
 
 
-The folllowing command can be copied and pasted for convenience:
+The following command can be copied and pasted for convenience:
 
 `sudo apt-get install qtbase5-dev qttools5-dev qttools5-dev-tools qtwebengine5-dev libqt5svg5-dev`
 
 ## <a name="thirdparty"/>3rd-Party Dependencies (optional step)
-Sigil will provide the extra third-party libs if you do nothing, but most (if not all) of Sigil's third-party dependencies should be avialable in your software repos. If you want to make use of them, `sudo apt-get install` the following packages.
+Sigil will provide the extra third-party libs if you do nothing, but most (if not all) of Sigil's third-party dependencies should be available in your software repos. If you want to make use of them, `sudo apt-get install` the following packages.
 
 + libhunspell-dev
 + libpcre2-dev
 + libminizip-dev
 
-The folllowing command can be copied and pasted for convenience:
+The following command can be copied and pasted for convenience:
 
 `sudo apt-get install libhunspell-dev libpcre2-dev libminizip-dev`
 
@@ -76,7 +76,7 @@ On Ubuntu/Debian `sudo apt-get install` (at a minimum) the following packages:
 + python3-css-parser (may have to use `pip3 install css-parser` if your distro has no package for this
 + python3-dulwich (unless your distro has very recent version (0.19.x) in its repos, you'll probably need to use `pip3 install dulwich` to install a new enough version that will work with Sigil. dulwich requires that the urllib3 and certifi modules be installed as well)
 
-The folllowing command can be copied and pasted for convenience:
+The following command can be copied and pasted for convenience:
 
 `sudo apt-get install python3-dev python3-pip python3-lxml python3-six python3-css-parser python3-dulwich`
 
@@ -91,7 +91,7 @@ That's all the Python 3.5 (or higher) stuff you will need to get Sigil "up and r
 + python3-cssselect
 + python3-chardet
 
-The folllowing command can be copied and pasted for convenience:
+The following command can be copied and pasted for convenience:
 
 `sudo apt-get install python3-tk python3-pyqt5 python3-pyqt5.qtwebengine python3-html5lib python3-regex python3-pil.imagetk python3-cssselect python3-chardet`
 

--- a/docs/Linux_Virtual_Plugin_Environment.md
+++ b/docs/Linux_Virtual_Plugin_Environment.md
@@ -14,7 +14,7 @@ Activate the new virtual environment with the following command:
 
 >`source sigilpy/bin/activate`
 
-Update the pip module in the virtual environement to the latest version (from pypi.org):
+Update the pip module in the virtual environment to the latest version (from pypi.org):
 
 >`python -m pip install --upgrade pip`
 

--- a/src/BookManipulation/FolderKeeper.h
+++ b/src/BookManipulation/FolderKeeper.h
@@ -157,7 +157,7 @@ public:
      * This function is a very fast O(1).
      *
      * @param identifier The identifier to search for.
-     * @return The searched-for resourcse.
+     * @return The searched-for resource.
      */
     Resource *GetResourceByIdentifier(const QString &identifier) const;
 
@@ -231,7 +231,7 @@ public:
     void WatchResourceFile(const Resource *resource);
 
     /**
-     * Dueing Save operations from Sigil we need to suspend/resume file watching.
+     * During Save operations from Sigil we need to suspend/resume file watching.
      */
     void SuspendWatchingResources();
     void ResumeWatchingResources();

--- a/src/Dialogs/ClipboardHistorySelector.h
+++ b/src/Dialogs/ClipboardHistorySelector.h
@@ -35,7 +35,7 @@
 #include "ui_ClipboardHistorySelector.h"
 
 /**
- * The clipboard history window used for selecing entries to paste.
+ * The clipboard history window used for selecting entries to paste.
  */
 class ClipboardHistorySelector : public QDialog
 {

--- a/src/Dialogs/Preferences.h
+++ b/src/Dialogs/Preferences.h
@@ -33,8 +33,8 @@
 /**
  * Allows the user to change settings related to how the application functions.
  *
- * The preferecnes exposed are instances of PreferencesWidget. They are loaded
- * and dynamically displayed based upon which one is seleted.
+ * The preferences exposed are instances of PreferencesWidget. They are loaded
+ * and dynamically displayed based upon which one is selected.
  */
 class Preferences : public QDialog
 {
@@ -72,7 +72,7 @@ public:
      */
     bool isRefreshClipHistoryLimitRequired();
     /**
-     * Check this after dialog closes to determine if BookBrowser needs to be refeshed
+     * Check this after dialog closes to determine if BookBrowser needs to be refreshed
      */
     bool isRefreshBookBrowserRequired();
     /**
@@ -109,7 +109,7 @@ private:
      *
      * The widget is added to the list of available widgets and when the
      * entry in the list is selected the widget it shown in the widget display
-     * area to the right of the avaliable widget list.
+     * area to the right of the available widget list.
      *
      * @param widget The PreferencesWidget to add to the dialog.
      */

--- a/src/Dialogs/Reports.h
+++ b/src/Dialogs/Reports.h
@@ -77,7 +77,7 @@ private:
      *
      * The widget is added to the list of available widgets and when the
      * entry in the list is selected the widget it shown in the widget display
-     * area to the right of the avaliable widget list.
+     * area to the right of the available widget list.
      *
      * @param widget The ReportsWidget to add to the dialog.
      */

--- a/src/Importers/ImportEPUB.h
+++ b/src/Importers/ImportEPUB.h
@@ -197,7 +197,7 @@ private:
 
     /**
      * The map of all files in the publication's manifest;
-     * The keys are the element ID's, the vaules are the
+     * The keys are the element ID's, the values are the
      * mimetype of the file.
      */
     QMap<QString, QString> m_FileMimetypes;

--- a/src/MainUI/BookBrowser.cpp
+++ b/src/MainUI/BookBrowser.cpp
@@ -396,9 +396,9 @@ QList <Resource *> BookBrowser::ValidSelectedSVGResources()
 
 QList <Resource *> BookBrowser::ValidSelectedJSResources()
 {
-    QStringList mts = QStringList() << "application/javscript" <<
+    QStringList mts = QStringList() << "application/javascript" <<
                                        "text/javascript" <<
-                                       "application/x-javscript" <<
+                                       "application/x-javascript" <<
                                        "application/ecmacript";
     return ValidSelectedResourcesByMT(mts);
 }

--- a/src/MainUI/MainWindow.h
+++ b/src/MainUI/MainWindow.h
@@ -560,7 +560,7 @@ private slots:
     void InspectHTML();
 
     /**
-     * Updates the cursor postion label to refelect the position of the
+     * Updates the cursor position label to reflect the position of the
      * cursor within the text.
      *
      * Use a negative value to to denote an unknown or invalid value.
@@ -976,7 +976,7 @@ private:
     PreviewWindow *m_PreviewWindow;
 
     /**
-     * The lable that displays the cursor position.
+     * The label that displays the cursor position.
      * Line and column.
      */
     QLabel *m_lbCursorPosition;

--- a/src/MainUI/OPFModel.h
+++ b/src/MainUI/OPFModel.h
@@ -73,7 +73,7 @@ public:
     void Refresh();
 
     /**
-     * Re-sorts the selected HTML entires in alphanumeric order
+     * Re-sorts the selected HTML entries in alphanumeric order
      */
     void SortHTML(QList <QModelIndex> index_list);
 

--- a/src/Misc/KeyboardShortcutManager.h
+++ b/src/Misc/KeyboardShortcutManager.h
@@ -93,7 +93,7 @@ public:
      * @param keySequence The key sequence to set.
      * @param isDefault Whether this is a default key sequence.
      *
-     * @return ture if the key sequence was set. False if it is already in use
+     * @return true if the key sequence was set. False if it is already in use
      * and was not set.
      */
     bool setKeySequence(const QString &id, const QKeySequence &keySequence, bool isDefault = false);
@@ -185,7 +185,7 @@ public:
     bool defaultKeySequenceInUse(const QKeySequence &keySequence);
 
     /**
-     * Store all managed information presistantly.
+     * Store all managed information persistently.
      */
     void writeSettings();
 

--- a/src/PCRE2/PCREReplaceTextBuilder.h
+++ b/src/PCRE2/PCREReplaceTextBuilder.h
@@ -51,7 +51,7 @@ public:
      * representing the captured subpatterns.
      * @param replacement_pattern The replacement pattern. Can be text or text
      * and control characters.
-     * @param[out] out The string to store the repacement.
+     * @param[out] out The string to store the replacement.
      *
      * @return True if replacement text is created.
      */

--- a/src/PCRE2/SPCRE.h
+++ b/src/PCRE2/SPCRE.h
@@ -111,9 +111,9 @@ public:
      */
     int getCaptureSubpatternCount();
     /**
-     * Convert a named capture group to its absolute numbered group equivelent.
+     * Convert a named capture group to its absolute numbered group equivalent.
      *
-     * @param name The named catpure group.
+     * @param name The named capture group.
      * @return The absolute numbered group represented by the name. -1 if the
      * named group does not exist within the pattern.
      */

--- a/src/Parsers/CSSInfo.h
+++ b/src/Parsers/CSSInfo.h
@@ -92,7 +92,7 @@ public:
      * Search for a CSSSelector with the same definition of original group text and pos as this,
      * and if found remove from the document text
      * If not found returns a null string.
-     * Note the caller must intialise a new CSSInfo object to re-parse the updated text for another remove.
+     * Note the caller must initialise a new CSSInfo object to re-parse the updated text for another remove.
      */
     QString removeMatchingSelectors(QList<CSSSelector *> cssSelectors);
 

--- a/src/Parsers/HTMLStyleInfo.h
+++ b/src/Parsers/HTMLStyleInfo.h
@@ -80,7 +80,7 @@ public:
      * Search for a CSSSelector with the same definition of original group text and pos as this,
      * and if found remove from the document text
      * If not found returns a null string.
-     * Note the caller must intialise a new HTMLStyleInfo object to re-parse the updated text for another remove.
+     * Note the caller must initialise a new HTMLStyleInfo object to re-parse the updated text for another remove.
      */
     QString removeMatchingSelectors(QList<CSSInfo::CSSSelector *> cssSelectors);
 

--- a/src/Query/CParser.cpp
+++ b/src/Query/CParser.cpp
@@ -528,7 +528,7 @@ CSelector* CParser::parsePseudoclassSelector()
         }
         else
         {
-            throw QueryParserException(error("impossibile"));
+            throw QueryParserException(error("impossible"));
         }
         return new CTextSelector(op, value);
     }

--- a/src/ResourceObjects/OPFResource.h
+++ b/src/ResourceObjects/OPFResource.h
@@ -138,7 +138,7 @@ public:
     QList<MetaEntry> GetDCMetadata() const;
 
     /**
-     * Returns list of any Media Overlay Active Class Selctors if defined in OPF metadata
+     * Returns list of any Media Overlay Active Class Selectors if defined in OPF metadata
      */
     QStringList GetMediaOverlayActiveClassSelectors() const;
     

--- a/src/Resource_Files/plugin_launchers/python/sigil_bs4/element.py
+++ b/src/Resource_Files/plugin_launchers/python/sigil_bs4/element.py
@@ -637,7 +637,7 @@ class PageElement(object):
         """Force an attribute value into a string representation.
 
         A multi-valued attribute will be converted into a
-        space-separated stirng.
+        space-separated string.
         """
         value = self.get(value, default)
         if isinstance(value, list) or isinstance(value, tuple):

--- a/src/ViewEditors/CodeViewEditor.h
+++ b/src/ViewEditors/CodeViewEditor.h
@@ -383,7 +383,7 @@ public:
     void SetReformatCSSEnabled(bool value);
 
     /**
-     * Control wheter the Reformat (clean) HTML submenu is avaliable on the context menu.
+     * Control whether the Reformat (clean) HTML submenu is available in the context menu.
      */
     bool ReformatHTMLEnabled();
     void SetReformatHTMLEnabled(bool value);


### PR DESCRIPTION
These are a bunch of user-facing and non-user-facing typo fixes.

Found via `codespell -q 3 -S "./3rdparty,*.ts,*.dic,*.aff,*.patch,./ChangeLog.txt,./src/Resource_Files/dictionaries" -L afile,aline,alog,ans,clen,doubleclick,inout,nd,pevent,pres,te,var`