### PR TITLE
Bug in Save Automate Lists...

### DIFF
--- a/src/Dialogs/AutomateEditor.cpp
+++ b/src/Dialogs/AutomateEditor.cpp
@@ -212,12 +212,6 @@ void AutomateEditor::saveData()
 
     qDebug() << "received from model: " << data;
     if (data.isEmpty()) {
-        QFile file(m_automate_path);
-        if (!file.open(QIODevice::WriteOnly)) {
-            QMessageBox::warning(this, tr("Warning"), tr("Cannot save empty automation list: Failed to create file %1").arg(m_automate_path));
-            return;
-        }
-        file.close();
         QDialog::accept();
         return;
     }

--- a/src/Dialogs/AutomateEditor.cpp
+++ b/src/Dialogs/AutomateEditor.cpp
@@ -212,6 +212,7 @@ void AutomateEditor::saveData()
 
     qDebug() << "received from model: " << data;
     if (data.isEmpty()) {
+        QMessageBox::warning(this, tr("Warning"), tr("Cannot save an empty automation list."));
         QDialog::accept();
         return;
     }


### PR DESCRIPTION
..when the automateXX.txt file does not exist.

Bug: Crash when saving empty automation lists for non-existent files.

Fix: Added empty data check in saveData, safe handling in SetNewAutomateList, and exception handling for CannotOpenFile.

Note: Save by Utility::WriteUnicodeTextFile moved to saveData (probably more logical).
