### PR TITLE
Revert PR #514 dulwich py3.7 compat workaround

### DIFF
--- a/src/Resource_Files/python3lib/repomanager.py
+++ b/src/Resource_Files/python3lib/repomanager.py
@@ -35,12 +35,6 @@ import filecmp
 from diffstat import diffstat
 from sdifflibparser import DiffCode, DifflibParser
 
-# Work around dulwich assumption about sys.argv being defined,
-# which is not automatically the case on Linux with distribution-provided
-# embedded Python versions older than 3.8.
-if (sys.hexversion < 0x03080000) and not hasattr(sys, 'argv'):
-    sys.argv = ['']
-
 import dulwich
 from dulwich import porcelain
 from dulwich.repo import Repo


### PR DESCRIPTION
Revert "Work around dulwich assumption about sys.argv being defined"
Revert "Restrict check for workaround to py3 <= 3.8.0"

This reverts commit 6fb4f5c0b0b168b223f564d2c908343ebe75d256 and commit b5e34ad7b9e0ca268bdb9682b0024c6521db96fc.

These were part of a compatibility workaround allowing proper Sigil operation on older Linuxes. Since Sigil has been requiring Python 3.9 or newer for a *while* now, this workaround wouldn't apply to any supported version any longer in the first place.
Let's minimize cruft by dropping the workaround altogether.