### PR TITLE
The consequence of naming environment variables

### DIFF
--- a/src/Resource_Files/python3lib/functionrep.py
+++ b/src/Resource_Files/python3lib/functionrep.py
@@ -118,7 +118,7 @@ def replace_swapcase_ignore_tags(match, number, file_name, metadata, data, *args
 
 
 def replace_debug_log(message):
-    logfile = os.environ.get('SIGIL_FUNCTION_REPLACE_LOG_FILE', None);
+    logfile = os.environ.get('SIGIL_FUNCTION_REPLACE_LOGFILE', None);
     if logfile:
         with open(logfile, "a", encoding="utf-8") as f:
             f.write(message)


### PR DESCRIPTION
For consistency of the notation of the word "LOGFILE" and compatibility with already existing notations in the Sigil User Guide:

`SIGIL_DEBUG_LOGFILE` Setting this to the full path (including file name and extension) to a user-writeable location will cause Sigil to output any additional debug information to that log file.  Unset this environment after debugging is important as this file will continue to build up output eventually filling up user disk space and slowing down Sigil.

`SIGIL_FUNCTION_REPLACE_LOGFILE` Setting this to the full path (including file name and extension) to a user-writeable location will cause Sigil to output any Python Function Replace log messages to that log file.  Unset this environment after debugging is important as this file will continue to build up output eventually filling up user disk space and slowing down Sigil.


**Note:** You could possibly close this PR and rename it in the User Guide, because the form “LOG_FILE” is in the [changelog](https://github.com/Sigil-Ebook/Sigil/blob/master/ChangeLog.txt#L81) and [here](https://www.mobileread.com/forums/showpost.php?p=4503805&postcount=96). But SOMETHING needs to be done.


