### PR TITLE
Zoom To Fit without triggering scrollbars

### DIFF
--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -363,7 +363,7 @@ void AdjustImage::doZoomOut()
 
 void AdjustImage::doZoomToFit()
 {
-    QSize windowSize = m_scrollArea->size();
+    QSize windowSize = m_scrollArea->viewport()->size();
     QSize labelSize = m_imageLabel->pixmap().size();
 
     double imageRatio = double(labelSize.height()) / labelSize.width();


### PR DESCRIPTION
Windows 10.
I’ve noticed that after using ‘Zoom To Fit’, the image is slightly too tall (or wide), and causes a scrollbar to appear.
Calculating the space using the viewport solves the problem (for me).