### PR TITLE
Add JSON file editing and syntax highlighting

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -377,6 +377,8 @@ set( MISC_FILES
     Misc/XHTMLHighlighter2.h
     Misc/CSSHighlighter.cpp
     Misc/CSSHighlighter.h
+    Misc/JSONHighlighter.cpp
+    Misc/JSONHighlighter.h
     Misc/PythonHighlighter.cpp
     Misc/PythonHighlighter.h
     Misc/HTMLEncodingResolver.cpp

--- a/src/Misc/JSONHighlighter.cpp
+++ b/src/Misc/JSONHighlighter.cpp
@@ -1,0 +1,150 @@
+/************************************************************************
+**
+**  Copyright (C) 2026  Sigil Contributors
+**
+**  This file is part of Sigil.
+**
+**  Sigil is free software: you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+*************************************************************************/
+
+#include <QApplication>
+
+#include "Misc/JSONHighlighter.h"
+#include "Misc/Utility.h"
+
+enum JSONBlockState {
+    JSONNormalState = 0,
+    JSONStringState = 1
+};
+
+JSONHighlighter::JSONHighlighter(QObject *parent)
+    : QSyntaxHighlighter(parent)
+{
+    SettingsStore settings;
+    if (Utility::IsDarkMode()) {
+        m_codeViewAppearance = settings.codeViewDarkAppearance();
+    } else {
+        m_codeViewAppearance = settings.codeViewAppearance();
+    }
+}
+
+void JSONHighlighter::do_rehighlight()
+{
+    QApplication::setOverrideCursor(Qt::WaitCursor);
+    rehighlight();
+    QApplication::restoreOverrideCursor();
+}
+
+void JSONHighlighter::highlightBlock(const QString &text)
+{
+    bool in_string = previousBlockState() == JSONStringState;
+    int string_start = in_string ? 0 : -1;
+    bool escaped = false;
+
+    setCurrentBlockState(JSONNormalState);
+
+    for (int i = 0; i < text.length(); ++i) {
+        const QChar ch = text.at(i);
+
+        if (in_string) {
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+            if (ch == QLatin1Char('\\')) {
+                escaped = true;
+                continue;
+            }
+            if (ch == QLatin1Char('"')) {
+                int length = i - string_start + 1;
+                if (IsKeyString(text, i)) {
+                    setFormat(string_start, length, m_codeViewAppearance.css_property_color);
+                } else {
+                    setFormat(string_start, length, m_codeViewAppearance.css_quote_color);
+                }
+                in_string = false;
+                string_start = -1;
+            }
+            continue;
+        }
+
+        if (ch == QLatin1Char('"')) {
+            in_string = true;
+            string_start = i;
+        } else if (ch.isDigit() || ch == QLatin1Char('-')) {
+            i = HighlightNumber(text, i) - 1;
+        } else if (ch.isLetter()) {
+            i = HighlightLiteral(text, i) - 1;
+        } else if (QStringLiteral("{}[],:").contains(ch)) {
+            setFormat(i, 1, m_codeViewAppearance.css_selector_color);
+        }
+    }
+
+    if (in_string) {
+        setCurrentBlockState(JSONStringState);
+        setFormat(string_start, text.length() - string_start, m_codeViewAppearance.css_quote_color);
+    }
+}
+
+bool JSONHighlighter::IsKeyString(const QString &text, int end_quote) const
+{
+    int pos = end_quote + 1;
+    while (pos < text.length() && text.at(pos).isSpace()) {
+        ++pos;
+    }
+    return pos < text.length() && text.at(pos) == QLatin1Char(':');
+}
+
+int JSONHighlighter::HighlightNumber(const QString &text, int start)
+{
+    int pos = start;
+
+    if (pos < text.length() && text.at(pos) == QLatin1Char('-')) {
+        ++pos;
+    }
+    while (pos < text.length() && text.at(pos).isDigit()) {
+        ++pos;
+    }
+    if (pos < text.length() && text.at(pos) == QLatin1Char('.')) {
+        ++pos;
+        while (pos < text.length() && text.at(pos).isDigit()) {
+            ++pos;
+        }
+    }
+    if (pos < text.length() && (text.at(pos) == QLatin1Char('e') || text.at(pos) == QLatin1Char('E'))) {
+        ++pos;
+        if (pos < text.length() && (text.at(pos) == QLatin1Char('+') || text.at(pos) == QLatin1Char('-'))) {
+            ++pos;
+        }
+        while (pos < text.length() && text.at(pos).isDigit()) {
+            ++pos;
+        }
+    }
+
+    if (pos > start && (pos - start > 1 || text.at(start) != QLatin1Char('-'))) {
+        setFormat(start, pos - start, m_codeViewAppearance.css_value_color);
+    }
+    return qMax(pos, start + 1);
+}
+
+int JSONHighlighter::HighlightLiteral(const QString &text, int start)
+{
+    static const QStringList literals = QStringList() << QStringLiteral("true")
+                                                      << QStringLiteral("false")
+                                                      << QStringLiteral("null");
+
+    foreach(const QString &literal, literals) {
+        if (text.mid(start, literal.length()) == literal) {
+            int end = start + literal.length();
+            if (end == text.length() || !text.at(end).isLetterOrNumber()) {
+                setFormat(start, literal.length(), m_codeViewAppearance.css_value_color);
+                return end;
+            }
+        }
+    }
+    return start + 1;
+}

--- a/src/Misc/JSONHighlighter.h
+++ b/src/Misc/JSONHighlighter.h
@@ -1,0 +1,41 @@
+/************************************************************************
+**
+**  Copyright (C) 2026  Sigil Contributors
+**
+**  This file is part of Sigil.
+**
+**  Sigil is free software: you can redistribute it and/or modify
+**  it under the terms of the GNU General Public License as published by
+**  the Free Software Foundation, either version 3 of the License, or
+**  (at your option) any later version.
+**
+*************************************************************************/
+
+#ifndef JSONHIGHLIGHTER_H
+#define JSONHIGHLIGHTER_H
+
+#include <QtGui/QSyntaxHighlighter>
+
+#include "Misc/SettingsStore.h"
+
+class JSONHighlighter : public QSyntaxHighlighter
+{
+    Q_OBJECT
+
+public:
+    explicit JSONHighlighter(QObject *parent);
+
+    void do_rehighlight();
+
+protected:
+    void highlightBlock(const QString &text);
+
+private:
+    bool IsKeyString(const QString &text, int end_quote) const;
+    int HighlightNumber(const QString &text, int start);
+    int HighlightLiteral(const QString &text, int start);
+
+    SettingsStore::CodeViewAppearance m_codeViewAppearance;
+};
+
+#endif // JSONHIGHLIGHTER_H

--- a/src/Misc/MediaTypes.cpp
+++ b/src/Misc/MediaTypes.cpp
@@ -38,7 +38,7 @@ const QStringList SVG_EXTENSIONS       = QStringList() << "svg";
 const QStringList SMIL_EXTENSIONS      = QStringList() << "smil";
 const QStringList JPG_EXTENSIONS       = QStringList() << "jpg"   << "jpeg";
 const QStringList TIFF_EXTENSIONS      = QStringList() << "tif"   << "tiff";
-const QStringList MISC_TEXT_EXTENSIONS = QStringList() << "txt"   << "js";
+const QStringList MISC_TEXT_EXTENSIONS = QStringList() << "txt"   << "js" << "json";
 const QStringList MISC_XML_EXTENSIONS  = QStringList() << "smil"  << "xpgt" << "pls" << "xml";
 const QStringList FONT_EXTENSIONS      = QStringList() << "ttf"   << "ttc"  << "otf" << "woff" << "woff2";
 const QStringList TEXT_EXTENSIONS      = QStringList() << "xhtml" << "html" << "htm";
@@ -219,6 +219,7 @@ void MediaTypes::SetExtToMTypeMap()
     m_ExtToMType[ "jpeg"  ] = "image/jpeg";
     m_ExtToMType[ "jpg"   ] = "image/jpeg";
     m_ExtToMType[ "js"    ] = "application/javascript";
+    m_ExtToMType[ "json"  ] = "application/json";
     m_ExtToMType[ "es"    ] = "application/ecmascript";
     m_ExtToMType[ "m4a"   ] = "audio/mp4";
     m_ExtToMType[ "m4v"   ] = "video/mp4";
@@ -324,6 +325,7 @@ void MediaTypes::SetMTypeToGroupMap()
     m_MTypeToGroup[ "application/vnd.adobe-page-template+xml" ] = "Misc";
 
     m_MTypeToGroup[ "application/javascript"                  ] = "Misc";
+    m_MTypeToGroup[ "application/json"                        ] = "Misc";
     m_MTypeToGroup[ "application/ecmascript"                  ] = "Misc";
     m_MTypeToGroup[ "application/x-javascript"                ] = "Misc";
     m_MTypeToGroup[ "text/javascript"                         ] = "Misc";
@@ -402,6 +404,7 @@ void MediaTypes::SetMTypeToRDescMap()
     m_MTypeToRDesc[ "application/vnd.adobe-page-template+xml" ] = "XMLResource";  // not a core media type
 
     m_MTypeToRDesc[ "application/javascript"                  ] = "MiscTextResource";
+    m_MTypeToRDesc[ "application/json"                        ] = "MiscTextResource";
     m_MTypeToRDesc[ "application/x-javascript"                ] = "MiscTextResource";
     m_MTypeToRDesc[ "application/ecmascript"                  ] = "MiscTextResource";
     m_MTypeToRDesc[ "text/javascript"                         ] = "MiscTextResource";
@@ -484,6 +487,7 @@ void MediaTypes::SetMTypeToExtMap()
 
     // Javascript
     m_MTypeToExt[ "application/javascript"                  ] = "js";
+    m_MTypeToExt[ "application/json"                        ] = "json";
     m_MTypeToExt[ "application/x-javascript"                ] = "js";
     m_MTypeToExt[ "application/ecmascript"                  ] = "es"; // js
     m_MTypeToExt[ "text/javascript"                         ] = "js";
@@ -512,4 +516,3 @@ void MediaTypes::SetMTypeToExtMap()
     m_MTypeToExt[ "application/ttml+xml"                    ] = "ttml";
 
 }
-

--- a/src/Tabs/MiscTextTab.cpp
+++ b/src/Tabs/MiscTextTab.cpp
@@ -24,8 +24,11 @@
 
 MiscTextTab::MiscTextTab(MiscTextResource *resource, int line_to_scroll_to, int position_to_scroll_to, QWidget *parent)
     :
-    TextTab(resource, CodeViewEditor::Highlight_NONE, line_to_scroll_to, position_to_scroll_to, parent)
+    TextTab(resource,
+            resource->GetMediaType() == "application/json" ? CodeViewEditor::Highlight_JSON : CodeViewEditor::Highlight_NONE,
+            line_to_scroll_to,
+            position_to_scroll_to,
+            parent)
 {
     connect(m_wCodeView, SIGNAL(OpenClipEditorRequest(ClipEditorModel::clipEntry *)), this, SIGNAL(OpenClipEditorRequest(ClipEditorModel::clipEntry *)));
 }
-

--- a/src/ViewEditors/CodeViewEditor.cpp
+++ b/src/ViewEditors/CodeViewEditor.cpp
@@ -57,6 +57,7 @@
 #include "Misc/XHTMLHighlighter2.h"
 #include "Dialogs/ClipEditor.h"
 #include "Misc/CSSHighlighter.h"
+#include "Misc/JSONHighlighter.h"
 #include "Misc/SettingsStore.h"
 #include "Misc/SpellCheck.h"
 #include "Misc/HTMLSpellCheck.h"
@@ -120,6 +121,8 @@ CodeViewEditor::CodeViewEditor(HighlighterType high_type, bool check_spelling, Q
         m_Highlighter = new XHTMLHighlighter2(check_spelling, this);
     } else if (high_type == CodeViewEditor::Highlight_CSS) {
         m_Highlighter = new CSSHighlighter(this);
+    } else if (high_type == CodeViewEditor::Highlight_JSON) {
+        m_Highlighter = new JSONHighlighter(this);
     } else {
         m_Highlighter = NULL;
     }
@@ -2394,11 +2397,14 @@ void CodeViewEditor::RehighlightDocument()
         XHTMLHighlighter2* xhl = qobject_cast<XHTMLHighlighter2*>(m_Highlighter);
         // XHTMLHighlighter* xhl = qobject_cast<XHTMLHighlighter*>(m_Highlighter);
         CSSHighlighter* chl = qobject_cast<CSSHighlighter*>(m_Highlighter);
+        JSONHighlighter* jhl = qobject_cast<JSONHighlighter*>(m_Highlighter);
         document()->blockSignals(true);
         if (xhl) {
             xhl->do_rehighlight();
         } else if (chl) {
             chl->do_rehighlight();
+        } else if (jhl) {
+            jhl->do_rehighlight();
         }
         document()->blockSignals(false);
     }

--- a/src/ViewEditors/CodeViewEditor.h
+++ b/src/ViewEditors/CodeViewEditor.h
@@ -67,7 +67,8 @@ public:
     enum HighlighterType {
         Highlight_NONE,  /**< No source code highlighting */
         Highlight_XHTML, /**< XHTML source code highlighting */
-        Highlight_CSS    /**< CSS source code highlighting */
+        Highlight_CSS,   /**< CSS source code highlighting */
+        Highlight_JSON   /**< JSON source code highlighting */
     };
 
     /**
@@ -876,4 +877,3 @@ private:
 };
 
 #endif // CODEVIEWEDITOR_H
-


### PR DESCRIPTION
## Summary

Adds basic JSON support to Sigil:

- recognizes `.json` as `application/json`
- maps `application/json` to `MiscTextResource`
- opens JSON files in Sigil's text editor
- adds JSON syntax highlighting for keys, strings, numbers, literals, and structure characters

## Testing

- `git diff --check`
- `cmake --build build --target sigil -j2`