### PR TITLE
Fix image editor undo history on resize dialog cancel

### DIFF
--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -238,6 +238,11 @@ void AdjustImage::saveToReverseHistory(QImage imageToSave)
 
 void AdjustImage::resizeImage(int targetW, int targetH)
 {
+    // no size change so don't record a history step or rescale the image
+    if (targetW == m_image.width() && targetH == m_image.height()) {
+        return;
+    }
+
     saveToHistoryWithClear(m_image);
     QPixmap pixmap(m_imageLabel->pixmap());
     pixmap = pixmap.scaled(targetW, targetH, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -363,7 +368,8 @@ void AdjustImage::toggleFullscreen()
 
 void AdjustImage::doResizeImage()
 {
-    saveToHistoryWithClear(m_image);
+    // only record history once the resize is actually applied in resizeImage()
+    // so canceling the dialog leaves the undo/redo stacks untouched
     int width = m_image.width();
     int height = m_image.height();
     ImageResizeDialog dlg(width, height, this);


### PR DESCRIPTION
## Problem

Opening the **Resize Image** dialog records the current image in the undo history before the dialog is shown.

This causes two incorrect behaviors:

1. **Canceling the dialog modifies history**

   * The current image is pushed onto the undo stack even though no edit was made.
   * The redo stack is cleared.
   * The next Undo may therefore appear to do nothing.

2. **Accepting a resize records the same state twice**

   * `doResizeImage()` records the current image before opening the dialog.
   * `resizeImage()` records it again before applying the resize.
   * This leaves a redundant entry in the undo sequence.

## Reproduction

### Cancel case

1. Open an image resource in the Image tab.
2. Rotate the image once.
3. Open **Resize Image** and click **Cancel**.
4. Press Undo (`Ctrl+Z`).

The first Undo does not visibly change the image; a second Undo is required to revert the rotation.

Existing redo history is also lost when the Resize dialog is opened and canceled.

### Accepted resize

1. Make an image edit such as Rotate.
2. Resize the image to different dimensions.
3. Undo the changes.

The undo sequence contains a redundant step where the image does not visibly change.

## Cause

`AdjustImage::doResizeImage()` calls:

`saveToHistoryWithClear(m_image)`

before showing `ImageResizeDialog`.

When the dialog is accepted, `resizeImage()` calls `saveToHistoryWithClear()` again before performing the actual resize.

As a result, history is modified when no edit is made and duplicated when a resize is performed.

## Change

* Move ownership of the resize history entry entirely to `resizeImage()`.
* Canceling the dialog now leaves the undo/redo stacks untouched.
* Return early when the requested dimensions match the current image size, avoiding a no-op history entry and unnecessary rescaling.

## Scope

* One file changed.
* No UI, settings, or serialization changes.
* A successful resize now creates exactly one undo history entry.
* Canceling or confirming an unchanged size creates no history entry.

## Verification

Tested with a fresh Debug build:

* Canceling **Resize Image** leaves undo/redo history unchanged.
* Existing redo history is preserved after canceling the dialog.
* A successful resize creates a single undo step.
* Confirming the current dimensions creates no undo step.
* Undo correctly restores the pre-resize image.

## Origin

The issue was originally identified while auditing the image-editing code in my downstream Sigil-Enhanced work (`3tic-project/Sigil-Enhanced`, commit `70c519ee6`, "limit image undo history steps and fix resize undo stack").

This patch was then isolated and rebuilt against the current Sigil master branch, and contains only the fix applicable to upstream Sigil.
