### PR TITLE
avoid unchanged search resource rewrites

### DIFF
--- a/src/Misc/SearchOperations.cpp
+++ b/src/Misc/SearchOperations.cpp
@@ -157,7 +157,9 @@ int SearchOperations::ReplaceHTMLInFile(const QString &search_regex,
     QString new_text;
     QString text = html_resource->GetText();
     std::tie(new_text, count) = PerformGlobalReplace(text, search_regex, replacement);
-    html_resource->SetText(new_text);
+    if (new_text != text) {
+        html_resource->SetText(new_text);
+    }
     return count;
  }
 
@@ -171,7 +173,9 @@ int SearchOperations::ReplaceTextInFile(const QString &search_regex,
     QString new_text;
     QString text = text_resource->GetText();
     std::tie(new_text, count) = PerformGlobalReplace(text, search_regex, replacement);
-    text_resource->SetText(new_text);
+    if (new_text != text) {
+        text_resource->SetText(new_text);
+    }
     return count;
 }
 
@@ -252,12 +256,16 @@ int SearchOperations::FunctionReplaceInAllFiles(const QString &search_regex,
             QWriteLocker locker(&html_resource->GetLock());
             QString text = html_resource->GetText();
             QString new_text = pr.DoFunctionSearchTextReplacementsInPython(fsp, search_regex, bookpath, text);
-            html_resource->SetText(new_text);
+            if (new_text != text) {
+                html_resource->SetText(new_text);
+            }
         } else if (text_resource) {
             QWriteLocker locker(&text_resource->GetLock());
             QString text = text_resource->GetText();
             QString new_text = pr.DoFunctionSearchTextReplacementsInPython(fsp, search_regex, bookpath, text);
-            text_resource->SetText(new_text);
+            if (new_text != text) {
+                text_resource->SetText(new_text);
+            }
         }
     }
     int count = pr.GetCurrentReplacementCountInPython(fsp);


### PR DESCRIPTION
## Summary

- Only call `SetText()` when a multi-file replacement actually changes a resource's text.
- Apply the same behavior to HTML resources, generic text resources, and Python function replacements.
- Preserve the existing replacement-count semantics, including replacements whose output is identical to the matched text.

## Problem

Multi-file replacement currently writes every resource back after calculating its replacement result, even when the resulting text is identical to the original text. This includes files with no matches and replacements such as `x` to `x`.

For loaded text resources, `SetText()` eventually calls `QTextDocument::setPlainText()`, which resets the document's undo/redo history and modified state. `HTMLResource::SetText()` also emits `TextChanging()` and runs resource tracking. As a result, an unchanged file can lose editor state and trigger unnecessary document and preview work simply because it was included in the search scope.

## Change

Compare each replacement result with the original text before writing it back:

```cpp
if (new_text != text) {
    html_resource->SetText(new_text);
}
```

The guard is applied at the four existing write sites:

- normal replacement for `HTMLResource`;
- normal replacement for `TextResource`;
- Python function replacement for `HTMLResource`;
- Python function replacement for `TextResource`.

This does not change regular-expression behavior, search scope, progress handling, Python session lifetime, or replacement counts.

## User impact

Replace All no longer reloads files whose content did not change. This preserves undo and modified state for those files and avoids unnecessary resource notifications and full-document reloads.

## Validation

Tested with a two-file EPUB in a macOS Debug build using Qt 6.7.3. Runtime breakpoints recorded calls to `HTMLResource::SetText()` and `TextResource::SetText()`.

| Scenario | Replacement count | Resource writes |
| --- | ---: | ---: |
| No match | 0 | 0 |
| Normal replacement with identical output | 1 | 0 |
| Normal replacement with changed output | 1 | 1 |
| Python replacement, two identical outputs | 2 | 0 |
| Python replacement, one changed and one identical output | 2 | 1 |
| Python text-resource replacement with changed output | 1 | 1 |
| Repeating the Python text replacement after the output is already identical | 1 | 0 additional writes |

