### PR TITLE
docs: fix typo wich -> which

### DIFF
--- a/3rdparty/hunspell/tests/suggestiontest/List_of_common_misspellings.txt
+++ b/3rdparty/hunspell/tests/suggestiontest/List_of_common_misspellings.txt
@@ -3962,7 +3962,7 @@ wholey	wholly
 wholy	wholly, holy
 whta	what
 whther	whether
-wich	which, witch
+which	which, witch
 widesread	widespread
 wief	wife
 wierd	weird


### PR DESCRIPTION
Corrects a single misspelling of `wich` in `3rdparty/hunspell/tests/suggestiontest/List_of_common_misspellings.txt`.

Documentation only, no behaviour change.