### PR TITLE
Crop Feature Improvements and New Refresh Function

### DIFF
--- a/ChangeLog.txt
+++ b/ChangeLog.txt
@@ -1,16 +1,20 @@
-Sigil 2.8.x
+Sigil 2.8.1
    Bug Fixes
-     - fix bug in AddExisting that could sometimes add duplicate image entries and skip some xhtml imports
+     - fix multiple bugs in AddExisting that could sometimes add duplicate image entries and skip some xhtml imports
      - fix bug that caused altimage urls on math tags to not be preoperly updated when moved or renamed
      - prevent crash in python function replace when re can not handle an expression that PCRE2 recognizes
      - fix bug when using OpenWith to re-open BBEdit.app on MacOS if BBEdit was already open
      - make launching PageEdit on MacOS via the Preferred XEditor always spawn a new copy of the PageApp
      - fix bugs when newlines were sometimes added to css files that threw off sync to Style.
      - fix bug that prevented Mend and Prettify from working in CV after a resource name change
+     - fix bug in TOCHTMLWriter that dropped a needed newline causing Preview to be misaligned.
+           Thank you BeckyEbook!
+     - add workarounds to macOS Tahoe bugs that prevent modal native dialogs from working
+     - fix bug in Create an HTML TOC that did not drop the busy cursor during requests for import
     
    New Features
      - add ability to use python regex in place of python re for embedded python controlled via an
-       environment variable (SIGIL_EMBED_PY_USES_REGEX).
+           environment variable (SIGIL_EMBED_PY_USES_REGEX).
 
      
 Sigil-2.8.0

--- a/src/MainUI/BookBrowser.cpp
+++ b/src/MainUI/BookBrowser.cpp
@@ -928,7 +928,6 @@ QStringList BookBrowser::AddExisting(bool only_multimedia, bool only_images, QSt
         bool CoverImageSemanticsSet = false;
         // try to see if an existing file has this filename and allow overwriting
         QString existing_book_path = m_Book->GetFolderKeeper()->GetBookPathByPathEnd(filename);
-        bool needsToUpdateOPF = true;
         
         if (!existing_book_path.isEmpty()) {
             // If this is an image prompt to replace it.
@@ -966,10 +965,10 @@ QStringList BookBrowser::AddExisting(bool only_multimedia, bool only_images, QSt
                     if (image_resource) {
                         CoverImageSemanticsSet = m_Book->GetOPF()->IsCoverImage(image_resource);
                     }
-                    // allow remove without updating OPF since overwrite
-                    // old_resource->Delete();
+                    old_resource->Delete();
+#if 0
                     m_Book->GetFolderKeeper()->RemoveWithoutUpdatingOPF(old_resource);
-                    needsToUpdateOPF = false;
+#endif
                     replacements_made = true;
                 } catch (ResourceDoesNotExist&) {
                     Utility::DisplayStdErrorDialog(tr("Unable to delete or replace file \"%1\".").arg(filename)

--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -43,11 +43,13 @@
 
 static const QString SETTINGS_GROUP = "adjust_image";
 static QStringList SAVE_QUALITY_MEDIATYPES = QStringList() << "image/jpeg" << "image/webp" << "image/avif" << "image/jxl";
+static const int HANDLE_SIZE = 10;
 
 AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWidget *parent) :
     QWidget(parent),
     ui(new Ui::AdjustImage),
-    m_mediatype(mediatype)
+    m_mediatype(mediatype),
+    m_draggingHandle(-1)
 {
     ui->setupUi(this);
     m_mainToolBar = ui->mainToolBar;
@@ -106,6 +108,8 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
         }
         m_scaleFactor = 1.0;
         m_croppingState = false;
+        m_croppingRegionSelected = false;
+        m_draggingHandle = -1;
         setCursor(Qt::ArrowCursor);
         updateActions(true);
         refreshLabel();
@@ -167,6 +171,26 @@ QRect AdjustImage::BuildRect(const QPoint& p1, const QPoint& p2)
     return arect;
 }
 
+int AdjustImage::GetHandleAtPosition(const QPoint& pos)
+{
+    QRect cropRect = BuildRect(m_rbstart, m_rbend);
+    int handle = -1;
+    
+    // Check which handle is being clicked (top-left, top-right, bottom-left, bottom-right, or edges)
+    if (QRect(cropRect.topLeft().x() - HANDLE_SIZE, cropRect.topLeft().y() - HANDLE_SIZE, HANDLE_SIZE * 2, HANDLE_SIZE * 2).contains(pos)) {
+        handle = 0; // top-left
+    } else if (QRect(cropRect.topRight().x() - HANDLE_SIZE, cropRect.topRight().y() - HANDLE_SIZE, HANDLE_SIZE * 2, HANDLE_SIZE * 2).contains(pos)) {
+        handle = 1; // top-right
+    } else if (QRect(cropRect.bottomLeft().x() - HANDLE_SIZE, cropRect.bottomLeft().y() - HANDLE_SIZE, HANDLE_SIZE * 2, HANDLE_SIZE * 2).contains(pos)) {
+        handle = 2; // bottom-left
+    } else if (QRect(cropRect.bottomRight().x() - HANDLE_SIZE, cropRect.bottomRight().y() - HANDLE_SIZE, HANDLE_SIZE * 2, HANDLE_SIZE * 2).contains(pos)) {
+        handle = 3; // bottom-right
+    } else if (cropRect.contains(pos)) {
+        handle = 4; // move entire rectangle
+    }
+    
+    return handle;
+}
 
 void AdjustImage::UpdateImageDescription()
 {
@@ -193,10 +217,13 @@ void AdjustImage::changeCroppingState(bool changeTo)
     m_croppingState = changeTo;
     ui->actionCrop->setDisabled(changeTo);
 
-    if (changeTo)
+    if (changeTo) {
         setCursor(Qt::CrossCursor);
-    else
+        m_statusBar->showMessage(tr("Click and drag to select crop area, then click Confirm"));
+    } else {
         setCursor(Qt::ArrowCursor);
+        m_statusBar->clearMessage();
+    }
 }
 
 void AdjustImage::refreshLabel()
@@ -297,27 +324,44 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
         {
             if (!m_croppingState) break;
             const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
-            m_croppingStart = me->pos() / m_scaleFactor;
-            // QRubberBand scales with m_imageLabel scaling
-            m_rbstart = me->pos();
-            m_rb->setGeometry(QRect(m_rbstart, QSize()));
-            m_rb->show();
+            
+            if (!m_croppingRegionSelected) {
+                // Initial selection mode
+                m_croppingStart = me->pos() / m_scaleFactor;
+                m_rbstart = me->pos();
+                m_rb->setGeometry(QRect(m_rbstart, QSize()));
+                m_rb->show();
+            } else {
+                // Adjustment mode - check if clicking on a handle
+                m_draggingHandle = GetHandleAtPosition(me->pos());
+                if (m_draggingHandle == -1) {
+                    // Not on handle, restart selection
+                    m_croppingRegionSelected = false;
+                    m_croppingStart = me->pos() / m_scaleFactor;
+                    m_rbstart = me->pos();
+                    m_rb->setGeometry(QRect(m_rbstart, QSize()));
+                    m_rb->show();
+                }
+            }
             break;
         }
 
         case QEvent::MouseButtonRelease:
         {
             if (!m_croppingState) break;
-            saveToHistoryWithClear(m_image);
             const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
-            m_croppingEnd = me->pos() / m_scaleFactor;
-            m_rbend = me->pos();
-            m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
-            m_rb->hide();
-            QRect rect = BuildRect(m_croppingStart, m_croppingEnd);
-            m_image = m_image.copy(rect);
-            refreshLabel();
-            changeCroppingState(false);
+            
+            if (!m_croppingRegionSelected && m_draggingHandle == -1) {
+                // Finish initial selection
+                m_croppingEnd = me->pos() / m_scaleFactor;
+                m_rbend = me->pos();
+                m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
+                m_croppingRegionSelected = true;
+                m_statusBar->showMessage(tr("Drag corners/edges to adjust, then click Confirm to crop"));
+            } else if (m_draggingHandle >= 0) {
+                // Finish handle dragging
+                m_draggingHandle = -1;
+            }
             break;
         }
 
@@ -331,9 +375,52 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
             int y_pos = std::round(position.y()/ m_scaleFactor);
             msg = msg.arg(x_pos).arg(y_pos).arg(sf);
             m_statusBar->showMessage(msg);
+            
             if (m_croppingState) {
-                m_rbend = position;
-                m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
+                if (!m_croppingRegionSelected && m_draggingHandle == -1) {
+                    // Drawing initial selection
+                    m_rbend = position;
+                    m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
+                } else if (m_croppingRegionSelected && m_draggingHandle >= 0) {
+                    // Dragging a handle to adjust crop area
+                    QRect currentRect = BuildRect(m_rbstart, m_rbend);
+                    
+                    if (m_draggingHandle == 0) {
+                        // top-left
+                        m_rbstart = position;
+                    } else if (m_draggingHandle == 1) {
+                        // top-right
+                        m_rbstart.setY(position.y());
+                        m_rbend.setX(position.x());
+                    } else if (m_draggingHandle == 2) {
+                        // bottom-left
+                        m_rbstart.setX(position.x());
+                        m_rbend.setY(position.y());
+                    } else if (m_draggingHandle == 3) {
+                        // bottom-right
+                        m_rbend = position;
+                    } else if (m_draggingHandle == 4) {
+                        // move entire rectangle
+                        QPoint delta = position - QPoint(currentRect.center().x(), currentRect.center().y());
+                        m_rbstart += delta;
+                        m_rbend += delta;
+                    }
+                    m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
+                }
+                
+                // Update cursor based on handle
+                if (m_croppingRegionSelected) {
+                    int handle = GetHandleAtPosition(position);
+                    if (handle == 0 || handle == 3) {
+                        setCursor(Qt::SizeFDiagCursor);
+                    } else if (handle == 1 || handle == 2) {
+                        setCursor(Qt::SizeBDiagCursor);
+                    } else if (handle == 4) {
+                        setCursor(Qt::SizeAllCursor);
+                    } else {
+                        setCursor(Qt::CrossCursor);
+                    }
+                }
             }
             break;
         }
@@ -347,7 +434,32 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
 
 void AdjustImage::doCrop()
 {
+    m_croppingRegionSelected = false;
+    m_draggingHandle = -1;
     changeCroppingState(true);
+}
+
+void AdjustImage::doCropConfirm()
+{
+    if (m_croppingRegionSelected) {
+        saveToHistoryWithClear(m_image);
+        m_croppingEnd = m_rbend / m_scaleFactor;
+        m_croppingStart = m_rbstart / m_scaleFactor;
+        QRect rect = BuildRect(m_croppingStart, m_croppingEnd);
+        m_image = m_image.copy(rect);
+        refreshLabel();
+        m_rb->hide();
+        m_croppingRegionSelected = false;
+        changeCroppingState(false);
+    }
+}
+
+void AdjustImage::doCropCancel()
+{
+    m_rb->hide();
+    m_croppingRegionSelected = false;
+    m_draggingHandle = -1;
+    changeCroppingState(false);
 }
 
 #if 0

--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -70,6 +70,8 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
     m_imageLabel->setBackgroundRole(QPalette::Base);
     m_imageLabel->setSizePolicy(QSizePolicy::Ignored, QSizePolicy::Ignored);
     m_imageLabel->setScaledContents(true);
+    // Center align the image
+    m_imageLabel->setAlignment(Qt::AlignCenter);
     m_imageLabel->installEventFilter(this);
     // rubber band must be a child of the m_imageLabel
     // otherwise there is a coordinate nightmare

--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -36,6 +36,7 @@
 #include <QImageWriter>
 #include <QInputDialog>
 #include <QKeySequence>
+#include <QPushButton>
 #include "Misc/SettingsStore.h"
 #include "Dialogs/ImageResizeDialog.h"
 #include "Widgets/AdjustImage.h"
@@ -44,12 +45,16 @@
 static const QString SETTINGS_GROUP = "adjust_image";
 static QStringList SAVE_QUALITY_MEDIATYPES = QStringList() << "image/jpeg" << "image/webp" << "image/avif" << "image/jxl";
 static const int HANDLE_SIZE = 10;
+static const int MIN_CROP_SIZE = 2;
 
 AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWidget *parent) :
     QWidget(parent),
     ui(new Ui::AdjustImage),
     m_mediatype(mediatype),
-    m_draggingHandle(-1)
+    m_draggingHandle(-1),
+    m_lastMousePos(0, 0),
+    m_cropConfirmBtn(nullptr),
+    m_cropCancelBtn(nullptr)
 {
     ui->setupUi(this);
     m_mainToolBar = ui->mainToolBar;
@@ -77,6 +82,10 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
 
     m_description = new QLabel;
     m_statusBar->addPermanentWidget(m_description);
+    
+    // Create crop confirmation buttons
+    CreateCropButtons();
+    
     // update tooltips on toolbar icons to include shortcut in a platform specific manner
     extendToolTip(ui->actionSave,        "Ctrl+S");    
     extendToolTip(ui->actionZoomIn,      "Ctrl++");
@@ -130,6 +139,27 @@ bool AdjustImage::isCropEnabled() { return ui->actionCrop->isEnabled(); }
 bool AdjustImage::isUndoEnabled() { return ui->actionUndo->isEnabled(); }
 bool AdjustImage::isRedoEnabled() { return ui->actionRedo->isEnabled(); }
 
+
+void AdjustImage::CreateCropButtons()
+{
+    // Create Confirm button
+    m_cropConfirmBtn = new QPushButton(tr("Confirm"));
+    m_cropConfirmBtn->setToolTip(tr("Confirm crop (Enter)"));
+    m_cropConfirmBtn->setMaximumWidth(80);
+    m_cropConfirmBtn->hide();
+    m_statusBar->addPermanentWidget(m_cropConfirmBtn);
+    
+    // Create Cancel button
+    m_cropCancelBtn = new QPushButton(tr("Cancel"));
+    m_cropCancelBtn->setToolTip(tr("Cancel crop (Esc)"));
+    m_cropCancelBtn->setMaximumWidth(80);
+    m_cropCancelBtn->hide();
+    m_statusBar->addPermanentWidget(m_cropCancelBtn);
+    
+    // Connect buttons
+    connect(m_cropConfirmBtn, SIGNAL(clicked()), this, SLOT(doCropConfirm()));
+    connect(m_cropCancelBtn, SIGNAL(clicked()), this, SLOT(doCropCancel()));
+}
 
 void AdjustImage::extendToolTip(QAction*m, const QString sc)
 {
@@ -192,6 +222,20 @@ int AdjustImage::GetHandleAtPosition(const QPoint& pos)
     return handle;
 }
 
+void AdjustImage::clampCropRectToBounds()
+{
+    // Calculate the display bounds of the image
+    int maxDisplayX = static_cast<int>(m_scaleFactor * m_image.width());
+    int maxDisplayY = static_cast<int>(m_scaleFactor * m_image.height());
+    
+    // Clamp rubber band coordinates to image bounds
+    m_rbstart.setX(std::max(0, std::min(m_rbstart.x(), maxDisplayX)));
+    m_rbstart.setY(std::max(0, std::min(m_rbstart.y(), maxDisplayY)));
+    
+    m_rbend.setX(std::max(0, std::min(m_rbend.x(), maxDisplayX)));
+    m_rbend.setY(std::max(0, std::min(m_rbend.y(), maxDisplayY)));
+}
+
 void AdjustImage::UpdateImageDescription()
 {
     QString colors_shades = m_image.isGrayscale() ? tr("shades") : tr("colors");
@@ -219,10 +263,22 @@ void AdjustImage::changeCroppingState(bool changeTo)
 
     if (changeTo) {
         setCursor(Qt::CrossCursor);
+        m_cropConfirmBtn->hide();
+        m_cropCancelBtn->hide();
         m_statusBar->showMessage(tr("Click and drag to select crop area, then click Confirm"));
     } else {
         setCursor(Qt::ArrowCursor);
+        m_cropConfirmBtn->hide();
+        m_cropCancelBtn->hide();
         m_statusBar->clearMessage();
+    }
+}
+
+void AdjustImage::showCropButtons()
+{
+    if (m_croppingRegionSelected) {
+        m_cropConfirmBtn->show();
+        m_cropCancelBtn->show();
     }
 }
 
@@ -331,6 +387,7 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
                 m_rbstart = me->pos();
                 m_rb->setGeometry(QRect(m_rbstart, QSize()));
                 m_rb->show();
+                m_lastMousePos = me->pos();
             } else {
                 // Adjustment mode - check if clicking on a handle
                 m_draggingHandle = GetHandleAtPosition(me->pos());
@@ -341,6 +398,11 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
                     m_rbstart = me->pos();
                     m_rb->setGeometry(QRect(m_rbstart, QSize()));
                     m_rb->show();
+                    m_cropConfirmBtn->hide();
+                    m_cropCancelBtn->hide();
+                } else if (m_draggingHandle == 4) {
+                    // Initialize for move operation
+                    m_lastMousePos = me->pos();
                 }
             }
             break;
@@ -358,8 +420,11 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
                 m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
                 m_croppingRegionSelected = true;
                 m_statusBar->showMessage(tr("Drag corners/edges to adjust, then click Confirm to crop"));
+                showCropButtons();
             } else if (m_draggingHandle >= 0) {
-                // Finish handle dragging
+                // Finish handle dragging and clamp to bounds
+                clampCropRectToBounds();
+                m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
                 m_draggingHandle = -1;
             }
             break;
@@ -400,10 +465,15 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
                         // bottom-right
                         m_rbend = position;
                     } else if (m_draggingHandle == 4) {
-                        // move entire rectangle
-                        QPoint delta = position - QPoint(currentRect.center().x(), currentRect.center().y());
-                        m_rbstart += delta;
-                        m_rbend += delta;
+                        // move entire rectangle - use previous position to calculate delta
+                        if (!m_lastMousePos.isNull()) {
+                            QPoint delta = position - m_lastMousePos;
+                            m_rbstart += delta;
+                            m_rbend += delta;
+                            // Clamp to image bounds during move
+                            clampCropRectToBounds();
+                        }
+                        m_lastMousePos = position;
                     }
                     m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
                 }
@@ -442,15 +512,33 @@ void AdjustImage::doCrop()
 void AdjustImage::doCropConfirm()
 {
     if (m_croppingRegionSelected) {
-        saveToHistoryWithClear(m_image);
+        // Convert display coordinates to image coordinates
         m_croppingEnd = m_rbend / m_scaleFactor;
         m_croppingStart = m_rbstart / m_scaleFactor;
         QRect rect = BuildRect(m_croppingStart, m_croppingEnd);
+        
+        // Validate minimum crop size
+        if (rect.width() < MIN_CROP_SIZE || rect.height() < MIN_CROP_SIZE) {
+            m_statusBar->showMessage(tr("Crop area too small (minimum 2x2 pixels)."));
+            return;
+        }
+        
+        // Validate crop area stays within image bounds
+        if (rect.x() < 0 || rect.y() < 0 || 
+            rect.right() > m_image.width() || 
+            rect.bottom() > m_image.height()) {
+            m_statusBar->showMessage(tr("Crop area exceeds image bounds."));
+            return;
+        }
+        
+        // Perform the crop
+        saveToHistoryWithClear(m_image);
         m_image = m_image.copy(rect);
         refreshLabel();
         m_rb->hide();
         m_croppingRegionSelected = false;
         changeCroppingState(false);
+        m_statusBar->showMessage(tr("Image cropped successfully."));
     }
 }
 
@@ -459,7 +547,9 @@ void AdjustImage::doCropCancel()
     m_rb->hide();
     m_croppingRegionSelected = false;
     m_draggingHandle = -1;
+    m_lastMousePos = QPoint(0, 0);
     changeCroppingState(false);
+    m_statusBar->showMessage(tr("Crop cancelled."));
 }
 
 #if 0

--- a/src/Widgets/AdjustImage.h
+++ b/src/Widgets/AdjustImage.h
@@ -92,7 +92,7 @@ private slots:
     bool eventFilter(QObject* watched, QEvent* event) override;
     void toggleShowToolbar(bool checked);
 
-   
+  
 private:
     void ReadSettings();
     void WriteSettings();
@@ -110,6 +110,7 @@ private:
     void UpdateImageDescription();
     QRect BuildRect(const QPoint& p1, const QPoint& p2);
     void extendToolTip(QAction* m, const QString sc);
+    int GetHandleAtPosition(const QPoint& pos);
     
     Ui::AdjustImage *ui;
     QVBoxLayout* vlayout;
@@ -127,6 +128,7 @@ private:
     QPoint m_rbstart;
     QPoint m_rbend;
     QRubberBand*  m_rb;
+    int m_draggingHandle;
 
     QString m_fileName;
     QString m_mediatype;

--- a/src/Widgets/AdjustImage.h
+++ b/src/Widgets/AdjustImage.h
@@ -81,6 +81,8 @@ public slots:
     void doRotateLeft();
     void doRotateRight();
     void doCrop();
+    void doCropConfirm();
+    void doCropCancel();
     void doResizeImage();
 
 signals:
@@ -90,7 +92,7 @@ private slots:
     bool eventFilter(QObject* watched, QEvent* event) override;
     void toggleShowToolbar(bool checked);
 
-  
+   
 private:
     void ReadSettings();
     void WriteSettings();
@@ -119,6 +121,7 @@ private:
     QLabel * m_description;
 
     bool m_croppingState;
+    bool m_croppingRegionSelected;
     QPoint m_croppingStart;
     QPoint m_croppingEnd;
     QPoint m_rbstart;

--- a/src/Widgets/AdjustImage.h
+++ b/src/Widgets/AdjustImage.h
@@ -111,6 +111,7 @@ private:
     QRect BuildRect(const QPoint& p1, const QPoint& p2);
     void extendToolTip(QAction* m, const QString sc);
     int GetHandleAtPosition(const QPoint& pos);
+    void clampCropRectToBounds();
     
     Ui::AdjustImage *ui;
     QVBoxLayout* vlayout;
@@ -127,6 +128,7 @@ private:
     QPoint m_croppingEnd;
     QPoint m_rbstart;
     QPoint m_rbend;
+    QPoint m_lastMousePos;
     QRubberBand*  m_rb;
     int m_draggingHandle;
 

--- a/src/Widgets/ImageView.cpp
+++ b/src/Widgets/ImageView.cpp
@@ -43,7 +43,7 @@ static const QString IMAGE_HTML_BASE =
     "<html>"
     "<head>"
     "<style type=\"text/css\">"
-    "body { -webkit-user-select: none; margin: 0; }"
+    "body { -webkit-user-select: none; margin: 0; display: flex; flex-direction: column; justify-content: center; align-items: center; min-height: 100vh; }"
     "div { text-align: center; margin: 8px 0; }"
     "img { display: block; margin: 0 auto; border: 1px solid; max-width: 100%; max-height: calc(100vh - 75px); }"
     "hr { width: 75%; }"


### PR DESCRIPTION
1. Images are now centered in the viewer screen.
2. Enhanced the crop feature for better usability.
- Press CTRL + Left Mouse Click to set the coordinates -> Click the Crop button.
3. Added a refresh function.
- You can now update the currently opened image file in the viewer after modifying it with an external editor or overwriting it by adding the same image file.