### PR TITLE
Crop Method Improvements

### DIFF
--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -33,6 +33,8 @@
 #include <QTransform>
 #include <QDebug>
 #include <QFileInfo>
+#include <QFile>
+#include <QLocale>
 #include <QImageWriter>
 #include <QInputDialog>
 #include <QKeySequence>
@@ -154,6 +156,8 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
     setWindowTitle(tr("Adjust Image"));
     if (!filepath.isEmpty()) {
         m_fileName = filepath;
+        m_ffsize = QFile(m_fileName).size() / 1024.0;
+        m_fsize =  QLocale().toString(m_ffsize, 'f', 2);
         m_image = QImage(m_fileName);
         if (m_image.isNull()) {
              QMessageBox::information(this,
@@ -161,6 +165,7 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
                                       tr("Cannot load %1.").arg(m_fileName));
              return;
         }
+        m_scaleFactor = 1.0;
         setCursor(Qt::ArrowCursor);
         updateActions(true);
         refreshLabel();
@@ -233,7 +238,7 @@ void AdjustImage::UpdateImageDescription()
     } else if (m_image.depth() > 0) {
         colorsInfo = QString(" %1bpp (%2 %3)").arg(m_image.bitPlaneCount()).arg(m_image.colorCount()).arg(colors_shades);
     }
-    QString description = QString("(%1px × %2px) %3%4").arg(m_image.width()).arg(m_image.height()).arg(grayscale_color).arg(colorsInfo);
+    QString description = QString("(%1px × %2px) %3 KB  %4%5").arg(m_image.width()).arg(m_image.height()).arg(m_fsize).arg(grayscale_color).arg(colorsInfo);
     m_description->setText(description);
 }
 
@@ -336,6 +341,11 @@ void AdjustImage::saveToReverseHistory(QImage imageToSave)
 
 void AdjustImage::resizeImage(int targetW, int targetH)
 {
+    // no size change so don't record a history step or rescale the image
+    if (targetW == m_image.width() && targetH == m_image.height()) {
+        return;
+    }
+
     clearCropSelection();
     saveToHistoryWithClear(m_image);
     QPixmap pixmap(m_imageLabel->pixmap());
@@ -660,7 +670,8 @@ void AdjustImage::toggleFullscreen()
 
 void AdjustImage::doResizeImage()
 {
-    saveToHistoryWithClear(m_image);
+    // only record history once the resize is actually applied in resizeImage()
+    // so canceling the dialog leaves the undo/redo stacks untouched
     int width = m_image.width();
     int height = m_image.height();
     ImageResizeDialog dlg(width, height, this);
@@ -722,6 +733,8 @@ void AdjustImage::doSave()
         bool success = writer.write(m_image);
         if (success) {
             m_statusBar->showMessage(tr("Image successfully saved."));
+            m_ffsize = QFile(m_fileName).size() / 1024.0;
+            m_fsize =  QLocale().toString(m_ffsize, 'f', 2);
         } else {
             m_statusBar->showMessage(tr("Image save failed: ") + writer.errorString() );
         }

--- a/src/Widgets/AdjustImage.cpp
+++ b/src/Widgets/AdjustImage.cpp
@@ -33,8 +33,6 @@
 #include <QTransform>
 #include <QDebug>
 #include <QFileInfo>
-#include <QFile>
-#include <QLocale>
 #include <QImageWriter>
 #include <QInputDialog>
 #include <QKeySequence>
@@ -46,10 +44,53 @@
 static const QString SETTINGS_GROUP = "adjust_image";
 static QStringList SAVE_QUALITY_MEDIATYPES = QStringList() << "image/jpeg" << "image/webp" << "image/avif" << "image/jxl";
 
+CornerHandle::CornerHandle(CornerPosition pos, QWidget* parent)
+    : QWidget(parent),
+      m_position(pos)
+{
+    setFixedSize(10, 10);
+    setAttribute(Qt::WA_TranslucentBackground, true);
+    setAttribute(Qt::WA_Hover, true);
+    switch (m_position) {
+        case CornerTopLeft:
+        case CornerBottomRight:
+            setCursor(Qt::SizeFDiagCursor);
+            break;
+        case CornerTopRight:
+        case CornerBottomLeft:
+            setCursor(Qt::SizeBDiagCursor);
+            break;
+        default:
+            break;
+    }
+    hide();
+}
+
+void CornerHandle::paintEvent(QPaintEvent* event)
+{
+    Q_UNUSED(event);
+    QPainter p(this);
+    p.setRenderHint(QPainter::Antialiasing);
+    bool hovered = underMouse();
+    p.setPen(QPen(QColor(0, 120, 215), 1.5));
+    p.setBrush(hovered ? QColor(200, 230, 255) : QColor(255, 255, 255));
+    p.drawEllipse(1, 1, width() - 2, height() - 2);
+}
+
 AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWidget *parent) :
     QWidget(parent),
     ui(new Ui::AdjustImage),
-    m_mediatype(mediatype)
+    m_mediatype(mediatype),
+    m_selectingCrop(false),
+    m_hasCropSelection(false),
+    m_cropRect(QRect()),
+    m_scaleFactor(1.0),
+    m_handleTL(nullptr),
+    m_handleTR(nullptr),
+    m_handleBL(nullptr),
+    m_handleBR(nullptr),
+    m_draggingHandle(CornerNone),
+    m_dragAnchor(QPoint())
 {
     ui->setupUi(this);
     m_mainToolBar = ui->mainToolBar;
@@ -69,11 +110,25 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
     // rubber band must be a child of the m_imageLabel
     // otherwise there is a coordinate nightmare
     m_rb = new QRubberBand(QRubberBand::Rectangle, m_imageLabel);
+    m_rb->setAttribute(Qt::WA_TransparentForMouseEvents, true);
     m_rb->hide();
+
+    m_handleTL = new CornerHandle(CornerTopLeft, m_imageLabel);
+    m_handleTR = new CornerHandle(CornerTopRight, m_imageLabel);
+    m_handleBL = new CornerHandle(CornerBottomLeft, m_imageLabel);
+    m_handleBR = new CornerHandle(CornerBottomRight, m_imageLabel);
+
+    m_handleTL->installEventFilter(this);
+    m_handleTR->installEventFilter(this);
+    m_handleBL->installEventFilter(this);
+    m_handleBR->installEventFilter(this);
 
     m_scrollArea = new QScrollArea;
     m_scrollArea->setBackgroundRole(QPalette::Dark);
     m_scrollArea->setWidget(m_imageLabel);
+    m_scrollArea->installEventFilter(this);
+    m_scrollArea->viewport()->installEventFilter(this);
+    setFocusPolicy(Qt::StrongFocus);
 
     m_description = new QLabel;
     m_statusBar->addPermanentWidget(m_description);
@@ -99,8 +154,6 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
     setWindowTitle(tr("Adjust Image"));
     if (!filepath.isEmpty()) {
         m_fileName = filepath;
-        m_ffsize = QFile(m_fileName).size() / 1024.0;
-        m_fsize =  QLocale().toString(m_ffsize, 'f', 2);
         m_image = QImage(m_fileName);
         if (m_image.isNull()) {
              QMessageBox::information(this,
@@ -108,8 +161,6 @@ AdjustImage::AdjustImage(const QString filepath, const QString& mediatype,  QWid
                                       tr("Cannot load %1.").arg(m_fileName));
              return;
         }
-        m_scaleFactor = 1.0;
-        m_croppingState = false;
         setCursor(Qt::ArrowCursor);
         updateActions(true);
         refreshLabel();
@@ -182,7 +233,7 @@ void AdjustImage::UpdateImageDescription()
     } else if (m_image.depth() > 0) {
         colorsInfo = QString(" %1bpp (%2 %3)").arg(m_image.bitPlaneCount()).arg(m_image.colorCount()).arg(colors_shades);
     }
-    QString description = QString("(%1px × %2px) %3 KB  %4%5").arg(m_image.width()).arg(m_image.height()).arg(m_fsize).arg(grayscale_color).arg(colorsInfo);
+    QString description = QString("(%1px × %2px) %3%4").arg(m_image.width()).arg(m_image.height()).arg(grayscale_color).arg(colorsInfo);
     m_description->setText(description);
 }
 
@@ -192,15 +243,57 @@ void AdjustImage::adjustScrollBar(QScrollBar *scrollBar, double factor)
     scrollBar->setValue(newValue);
 }
 
-void AdjustImage::changeCroppingState(bool changeTo)
+void AdjustImage::clearCropSelection()
 {
-    m_croppingState = changeTo;
-    ui->actionCrop->setDisabled(changeTo);
+    m_selectingCrop = false;
+    m_draggingHandle = CornerNone;
+    m_hasCropSelection = false;
+    m_cropRect = QRect();
+    if (m_rb) {
+        m_rb->hide();
+    }
+    if (m_handleTL) m_handleTL->hide();
+    if (m_handleTR) m_handleTR->hide();
+    if (m_handleBL) m_handleBL->hide();
+    if (m_handleBR) m_handleBR->hide();
 
-    if (changeTo)
-        setCursor(Qt::CrossCursor);
-    else
-        setCursor(Qt::ArrowCursor);
+    if (ui && ui->actionCrop) {
+        ui->actionCrop->setEnabled(false);
+    }
+    setCursor(Qt::ArrowCursor);
+}
+
+void AdjustImage::updateCropHandles()
+{
+    if (!m_hasCropSelection || !m_handleTL || !m_handleTR || !m_handleBL || !m_handleBR) {
+        return;
+    }
+    QRect rbRect = m_rb->geometry();
+    int left = rbRect.left();
+    int top = rbRect.top();
+    int right = rbRect.right();
+    int bottom = rbRect.bottom();
+
+    int w = m_handleTL->width();
+    int h = m_handleTL->height();
+
+    int maxLabelX = qMax(0, m_imageLabel->width() - w);
+    int maxLabelY = qMax(0, m_imageLabel->height() - h);
+
+    m_handleTL->move(qBound(0, left - w / 2, maxLabelX),   qBound(0, top - h / 2, maxLabelY));
+    m_handleTR->move(qBound(0, right - w / 2, maxLabelX),  qBound(0, top - h / 2, maxLabelY));
+    m_handleBL->move(qBound(0, left - w / 2, maxLabelX),   qBound(0, bottom - h / 2, maxLabelY));
+    m_handleBR->move(qBound(0, right - w / 2, maxLabelX),  qBound(0, bottom - h / 2, maxLabelY));
+
+    m_handleTL->show();
+    m_handleTR->show();
+    m_handleBL->show();
+    m_handleBR->show();
+
+    m_handleTL->raise();
+    m_handleTR->raise();
+    m_handleBL->raise();
+    m_handleBR->raise();
 }
 
 void AdjustImage::refreshLabel()
@@ -212,6 +305,7 @@ void AdjustImage::refreshLabel()
 
 void AdjustImage::rotateImage(int angle)
 {
+    clearCropSelection();
     saveToHistoryWithClear(m_image);
     QPixmap pixmap(m_imageLabel->pixmap());
     QTransform rm;
@@ -242,11 +336,7 @@ void AdjustImage::saveToReverseHistory(QImage imageToSave)
 
 void AdjustImage::resizeImage(int targetW, int targetH)
 {
-    // no size change so don't record a history step or rescale the image
-    if (targetW == m_image.width() && targetH == m_image.height()) {
-        return;
-    }
-
+    clearCropSelection();
     saveToHistoryWithClear(m_image);
     QPixmap pixmap(m_imageLabel->pixmap());
     pixmap = pixmap.scaled(targetW, targetH, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -264,6 +354,14 @@ void AdjustImage::scaleImageBy(double factor)
 
     ui->actionZoomIn->setEnabled(m_scaleFactor < 3.0);
     ui->actionZoomOut->setEnabled(m_scaleFactor > 0.333);
+    if (m_hasCropSelection && !m_cropRect.isEmpty()) {
+        QRect newRb(std::round(m_cropRect.x() * m_scaleFactor),
+                    std::round(m_cropRect.y() * m_scaleFactor),
+                    std::round(m_cropRect.width() * m_scaleFactor),
+                    std::round(m_cropRect.height() * m_scaleFactor));
+        m_rb->setGeometry(newRb);
+        updateCropHandles();
+    }
     emit InternalZoomFactorChanged(m_scaleFactor);
 }
 
@@ -277,12 +375,20 @@ void AdjustImage::scaleImageUsing(double factor)
 
     ui->actionZoomIn->setEnabled(m_scaleFactor < 3.0);
     ui->actionZoomOut->setEnabled(m_scaleFactor > 0.333);
+    if (m_hasCropSelection && !m_cropRect.isEmpty()) {
+        QRect newRb(std::round(m_cropRect.x() * m_scaleFactor),
+                    std::round(m_cropRect.y() * m_scaleFactor),
+                    std::round(m_cropRect.width() * m_scaleFactor),
+                    std::round(m_cropRect.height() * m_scaleFactor));
+        m_rb->setGeometry(newRb);
+        updateCropHandles();
+    }
 }
 
 
 void AdjustImage::updateActions(bool updateTo)
 {
-    ui->actionCrop->setEnabled(updateTo);
+    ui->actionCrop->setEnabled(updateTo && m_hasCropSelection);
     ui->actionResizeImage->setEnabled(updateTo);
     ui->actionRotateLeft->setEnabled(updateTo);
     ui->actionRotateRight->setEnabled(updateTo);
@@ -295,8 +401,141 @@ void AdjustImage::updateActions(bool updateTo)
 
 // Slots
 
+void AdjustImage::keyPressEvent(QKeyEvent* event)
+{
+    if (event->key() == Qt::Key_Escape && m_hasCropSelection) {
+        clearCropSelection();
+        m_statusBar->showMessage(tr("Crop cancelled."));
+        event->accept();
+        return;
+    }
+    QWidget::keyPressEvent(event);
+}
+
 bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
 {
+    // Global key handling across all watched widgets (imageLabel, corner handles, scrollArea, viewport)
+    if (event->type() == QEvent::KeyPress) {
+        const QKeyEvent* const ke = static_cast<const QKeyEvent*>(event);
+        if (ke->key() == Qt::Key_Escape && m_hasCropSelection) {
+            clearCropSelection();
+            m_statusBar->showMessage(tr("Crop cancelled."));
+            return true;
+        }
+        if (ke->key() == Qt::Key_Control) {
+            setCursor(Qt::CrossCursor);
+        }
+    }
+    else if (event->type() == QEvent::KeyRelease) {
+        const QKeyEvent* const ke = static_cast<const QKeyEvent*>(event);
+        if (ke->key() == Qt::Key_Control && !m_selectingCrop && m_draggingHandle == CornerNone) {
+            setCursor(Qt::ArrowCursor);
+        }
+    }
+
+    // Handle events from CornerHandle widgets
+    CornerHandle* handle = nullptr;
+    if (watched == m_handleTL) handle = m_handleTL;
+    else if (watched == m_handleTR) handle = m_handleTR;
+    else if (watched == m_handleBL) handle = m_handleBL;
+    else if (watched == m_handleBR) handle = m_handleBR;
+
+    if (handle) {
+        switch (event->type())
+        {
+            case QEvent::MouseButtonPress:
+            {
+                const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
+                if (me->button() == Qt::LeftButton) {
+                    m_draggingHandle = handle->position();
+                    QRect rbRect = m_rb->geometry();
+                    switch (m_draggingHandle) {
+                        case CornerTopLeft:
+                            m_dragAnchor = QPoint(rbRect.right(), rbRect.bottom());
+                            break;
+                        case CornerTopRight:
+                            m_dragAnchor = QPoint(rbRect.left(), rbRect.bottom());
+                            break;
+                        case CornerBottomLeft:
+                            m_dragAnchor = QPoint(rbRect.right(), rbRect.top());
+                            break;
+                        case CornerBottomRight:
+                            m_dragAnchor = QPoint(rbRect.left(), rbRect.top());
+                            break;
+                        default:
+                            break;
+                    }
+                    setFocus();
+                    return true;
+                }
+                break;
+            }
+
+            case QEvent::MouseMove:
+            {
+                if (m_draggingHandle != CornerNone) {
+                    const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
+                    QPoint pos = handle->mapToParent(me->pos());
+                    int maxX = qMax(0, m_imageLabel->width() - 1);
+                    int maxY = qMax(0, m_imageLabel->height() - 1);
+                    pos.setX(qBound(0, pos.x(), maxX));
+                    pos.setY(qBound(0, pos.y(), maxY));
+
+                    QRect newRbRect = BuildRect(m_dragAnchor, pos);
+                    m_rb->setGeometry(newRbRect);
+
+                    int imgLeft = std::round(newRbRect.left() / m_scaleFactor);
+                    int imgTop = std::round(newRbRect.top() / m_scaleFactor);
+                    int imgRight = std::round(newRbRect.right() / m_scaleFactor);
+                    int imgBottom = std::round(newRbRect.bottom() / m_scaleFactor);
+                    m_cropRect = BuildRect(QPoint(imgLeft, imgTop), QPoint(imgRight, imgBottom)).intersected(m_image.rect());
+
+                    updateCropHandles();
+
+                    QString sf = QString::number(m_scaleFactor, 'f', 4);
+                    QString msg = tr("(x,y) coordinates:") + " (%1,%2)  " + tr("Zoom") + " (%3)";
+                    msg = msg.arg(std::round(pos.x() / m_scaleFactor)).arg(std::round(pos.y() / m_scaleFactor)).arg(sf);
+                    m_statusBar->showMessage(msg);
+                    return true;
+                }
+                break;
+            }
+
+            case QEvent::MouseButtonRelease:
+            {
+                if (m_draggingHandle != CornerNone) {
+                    const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
+                    if (me->button() == Qt::LeftButton) {
+                        m_draggingHandle = CornerNone;
+                        QRect rbRect = m_rb->geometry();
+                        int imgLeft = std::round(rbRect.left() / m_scaleFactor);
+                        int imgTop = std::round(rbRect.top() / m_scaleFactor);
+                        int imgRight = std::round(rbRect.right() / m_scaleFactor);
+                        int imgBottom = std::round(rbRect.bottom() / m_scaleFactor);
+                        QRect rect = BuildRect(QPoint(imgLeft, imgTop), QPoint(imgRight, imgBottom)).intersected(m_image.rect());
+
+                        if (rect.width() > 2 && rect.height() > 2) {
+                            m_cropRect = rect;
+                            m_hasCropSelection = true;
+                            ui->actionCrop->setEnabled(true);
+                            updateCropHandles();
+                            m_statusBar->showMessage(tr("Crop area selected: (%1,%2) %3x%4 px. Click Crop to execute.")
+                                                     .arg(rect.x()).arg(rect.y()).arg(rect.width()).arg(rect.height()));
+                        } else {
+                            clearCropSelection();
+                        }
+                        return true;
+                    }
+                }
+                break;
+            }
+
+            default:
+                break;
+        }
+        return false;
+    }
+
     if (watched != m_imageLabel)
         return false;
 
@@ -304,29 +543,60 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
     {
         case QEvent::MouseButtonPress:
         {
-            if (!m_croppingState) break;
+            setFocus();
             const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
-            m_croppingStart = me->pos() / m_scaleFactor;
-            // QRubberBand scales with m_imageLabel scaling
-            m_rbstart = me->pos();
-            m_rb->setGeometry(QRect(m_rbstart, QSize()));
-            m_rb->show();
+            if (me->button() == Qt::LeftButton && (me->modifiers() & Qt::ControlModifier)) {
+                clearCropSelection();
+                m_selectingCrop = true;
+                QPoint pos = me->pos();
+                int maxX = qMax(0, m_imageLabel->width() - 1);
+                int maxY = qMax(0, m_imageLabel->height() - 1);
+                pos.setX(qBound(0, pos.x(), maxX));
+                pos.setY(qBound(0, pos.y(), maxY));
+                m_rbstart = pos;
+                m_rbend = pos;
+                m_croppingStart = QPoint(std::round(pos.x() / m_scaleFactor), std::round(pos.y() / m_scaleFactor));
+                m_rb->setGeometry(QRect(m_rbstart, QSize()));
+                m_rb->show();
+                setCursor(Qt::CrossCursor);
+                return true;
+            }
             break;
         }
 
         case QEvent::MouseButtonRelease:
         {
-            if (!m_croppingState) break;
-            saveToHistoryWithClear(m_image);
             const QMouseEvent* const me = static_cast<const QMouseEvent*>(event);
-            m_croppingEnd = me->pos() / m_scaleFactor;
-            m_rbend = me->pos();
-            m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
-            m_rb->hide();
-            QRect rect = BuildRect(m_croppingStart, m_croppingEnd);
-            m_image = m_image.copy(rect);
-            refreshLabel();
-            changeCroppingState(false);
+            if (me->button() == Qt::LeftButton && m_selectingCrop) {
+                m_selectingCrop = false;
+                QPoint pos = me->pos();
+                int maxX = qMax(0, m_imageLabel->width() - 1);
+                int maxY = qMax(0, m_imageLabel->height() - 1);
+                pos.setX(qBound(0, pos.x(), maxX));
+                pos.setY(qBound(0, pos.y(), maxY));
+                m_rbend = pos;
+                m_croppingEnd = QPoint(std::round(pos.x() / m_scaleFactor), std::round(pos.y() / m_scaleFactor));
+
+                QRect rect = BuildRect(m_croppingStart, m_croppingEnd).intersected(m_image.rect());
+                if (rect.width() > 2 && rect.height() > 2) {
+                    m_cropRect = rect;
+                    m_hasCropSelection = true;
+                    m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
+                    m_rb->show();
+                    ui->actionCrop->setEnabled(true);
+                    updateCropHandles();
+                    m_statusBar->showMessage(tr("Crop area selected: (%1,%2) %3x%4 px. Click Crop to execute.")
+                                             .arg(rect.x()).arg(rect.y()).arg(rect.width()).arg(rect.height()));
+                } else {
+                    clearCropSelection();
+                }
+                if (me->modifiers() & Qt::ControlModifier) {
+                    setCursor(Qt::CrossCursor);
+                } else {
+                    setCursor(Qt::ArrowCursor);
+                }
+                return true;
+            }
             break;
         }
 
@@ -337,12 +607,23 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
             QString sf = QString::number(m_scaleFactor, 'f', 4);
             QString msg = tr("(x,y) coordinates:") + " (%1,%2)  " + tr("Zoom") + " (%3)";
             int x_pos = std::round(position.x() / m_scaleFactor);
-            int y_pos = std::round(position.y()/ m_scaleFactor);
+            int y_pos = std::round(position.y() / m_scaleFactor);
             msg = msg.arg(x_pos).arg(y_pos).arg(sf);
             m_statusBar->showMessage(msg);
-            if (m_croppingState) {
-                m_rbend = position;
+
+            if (m_selectingCrop) {
+                QPoint pos = position;
+                int maxX = qMax(0, m_imageLabel->width() - 1);
+                int maxY = qMax(0, m_imageLabel->height() - 1);
+                pos.setX(qBound(0, pos.x(), maxX));
+                pos.setY(qBound(0, pos.y(), maxY));
+                m_rbend = pos;
                 m_rb->setGeometry(BuildRect(m_rbstart, m_rbend));
+                setCursor(Qt::CrossCursor);
+            } else if (me->modifiers() & Qt::ControlModifier) {
+                setCursor(Qt::CrossCursor);
+            } else if (cursor().shape() != Qt::ArrowCursor) {
+                setCursor(Qt::ArrowCursor);
             }
             break;
         }
@@ -356,7 +637,14 @@ bool AdjustImage::eventFilter(QObject* watched, QEvent* event)
 
 void AdjustImage::doCrop()
 {
-    changeCroppingState(true);
+    if (!m_hasCropSelection || m_cropRect.isEmpty()) {
+        return;
+    }
+    saveToHistoryWithClear(m_image);
+    m_image = m_image.copy(m_cropRect);
+    clearCropSelection();
+    refreshLabel();
+    m_statusBar->showMessage(tr("Image cropped."));
 }
 
 #if 0
@@ -372,8 +660,7 @@ void AdjustImage::toggleFullscreen()
 
 void AdjustImage::doResizeImage()
 {
-    // only record history once the resize is actually applied in resizeImage()
-    // so canceling the dialog leaves the undo/redo stacks untouched
+    saveToHistoryWithClear(m_image);
     int width = m_image.width();
     int height = m_image.height();
     ImageResizeDialog dlg(width, height, this);
@@ -435,8 +722,6 @@ void AdjustImage::doSave()
         bool success = writer.write(m_image);
         if (success) {
             m_statusBar->showMessage(tr("Image successfully saved."));
-            m_ffsize = QFile(m_fileName).size() / 1024.0;
-            m_fsize =  QLocale().toString(m_ffsize, 'f', 2);
         } else {
             m_statusBar->showMessage(tr("Image save failed: ") + writer.errorString() );
         }
@@ -456,6 +741,7 @@ void AdjustImage::toggleShowToolbar(bool checked)
 
 void AdjustImage::doUndo()
 {
+    clearCropSelection();
     saveToReverseHistory(m_image);
     if (!m_history.isEmpty()) {
         m_image = m_history.last();
@@ -468,6 +754,7 @@ void AdjustImage::doUndo()
 
 void AdjustImage::doRedo()
 {
+    clearCropSelection();
     saveToHistory(m_image);
     if (!m_reverseHistory.isEmpty()) {
         m_image = m_reverseHistory.last();

--- a/src/Widgets/AdjustImage.h
+++ b/src/Widgets/AdjustImage.h
@@ -56,6 +56,27 @@ namespace Ui {
 class AdjustImage;
 }
 
+enum CornerPosition {
+    CornerNone = 0,
+    CornerTopLeft,
+    CornerTopRight,
+    CornerBottomLeft,
+    CornerBottomRight
+};
+
+class CornerHandle : public QWidget
+{
+public:
+    CornerHandle(CornerPosition pos, QWidget* parent = nullptr);
+    CornerPosition position() const { return m_position; }
+
+protected:
+    void paintEvent(QPaintEvent* event) override;
+
+private:
+    CornerPosition m_position;
+};
+
 class AdjustImage : public QWidget
 {
     Q_OBJECT
@@ -86,6 +107,9 @@ public slots:
 signals:
     void InternalZoomFactorChanged(double factor);
 
+protected:
+    void keyPressEvent(QKeyEvent* event) override;
+
 private slots:
     bool eventFilter(QObject* watched, QEvent* event) override;
     void toggleShowToolbar(bool checked);
@@ -96,7 +120,8 @@ private:
     void WriteSettings();
     void ConnectSignalsToSlots();
     void adjustScrollBar(QScrollBar *scrollBar, double factor);
-    void changeCroppingState(bool changeTo);
+    void clearCropSelection();
+    void updateCropHandles();
     void refreshLabel();
     void rotateImage(int angle);
     void resizeImage(int tgtw, int tgth); 
@@ -118,17 +143,24 @@ private:
     QImage m_image;
     QLabel * m_description;
 
-    bool m_croppingState;
+    bool m_selectingCrop;
+    bool m_hasCropSelection;
+    QRect m_cropRect;
     QPoint m_croppingStart;
     QPoint m_croppingEnd;
     QPoint m_rbstart;
     QPoint m_rbend;
     QRubberBand*  m_rb;
 
-    QString m_fileName;  // this is the full absolute path
+    CornerHandle* m_handleTL;
+    CornerHandle* m_handleTR;
+    CornerHandle* m_handleBL;
+    CornerHandle* m_handleBR;
+    CornerPosition m_draggingHandle;
+    QPoint m_dragAnchor;
+
+    QString m_fileName;
     QString m_mediatype;
-    double m_ffsize = 0.0;
-    QString m_fsize;
 
     QVector<QImage> m_history;
     QVector<QImage> m_reverseHistory;

--- a/src/Widgets/AdjustImage.h
+++ b/src/Widgets/AdjustImage.h
@@ -170,7 +170,6 @@ private:
     int m_webp_quality;
     int m_jxl_quality;
     int m_avif_quality;
-
 };
 
 #endif // ADJUSTIMAGE_H

--- a/src/Widgets/AdjustImage.h
+++ b/src/Widgets/AdjustImage.h
@@ -159,8 +159,10 @@ private:
     CornerPosition m_draggingHandle;
     QPoint m_dragAnchor;
 
-    QString m_fileName;
+    QString m_fileName;  // this is the full absolute path
     QString m_mediatype;
+    double m_ffsize = 0.0;
+    QString m_fsize;
 
     QVector<QImage> m_history;
     QVector<QImage> m_reverseHistory;
@@ -170,6 +172,7 @@ private:
     int m_webp_quality;
     int m_jxl_quality;
     int m_avif_quality;
+
 };
 
 #endif // ADJUSTIMAGE_H


### PR DESCRIPTION
1. Set Crop Area: Hold Ctrl + Left-click and drag to define the crop coordinates.
2. Adjust Coordinates: Click and drag any of the four corners of the selected area to modify the coordinates.
3. Cancel Crop Area: Hold Ctrl and click anywhere inside the image area to cancel the selected coordinates.
4. Execute Crop: Click the Crop button while the coordinates are set to crop the image to the specified area.

Could you take a look at the code? I'm not a professional developer, so feel free to reject it if you spot any issues.